### PR TITLE
PG: Fix update limit

### DIFF
--- a/src/pg/sql/upsert.js
+++ b/src/pg/sql/upsert.js
@@ -15,8 +15,13 @@ export function patch(object, arg, options) {
 
   return sql`
     UPDATE "${raw(table)}" SET ${getUpdates(row, options)}
-    WHERE ${join(where, ` AND `)}
-    LIMIT 1
+    WHERE ${
+      isPlainObject(arg)
+        ? sql`"${raw(idCol)}" = (
+            SELECT "${raw(idCol)}" FROM "${raw(table)}"
+            WHERE ${join(where, ` AND `)} LIMIT 1)`
+        : join(where, ` AND `)
+    }
     RETURNING (${getSelectCols(table)} || ${meta})`;
 }
 

--- a/src/pg/test/db/dbWrite.test.js
+++ b/src/pg/test/db/dbWrite.test.js
@@ -73,7 +73,7 @@ describe('postgres', () => {
       UPDATE "user" SET
         "name" = ${data.name},
         "updatedAt" = ${nowTimestamp}
-      WHERE "id" = ${id} LIMIT 1
+      WHERE "id" = ${id}
       RETURNING ( to_jsonb ( "user" ) || jsonb_build_object ( '$key' , "id" , '$ver' , cast ( extract ( epoch from now ( ) ) as integer ) ) )
     `;
     expectSql(mockQuery.mock.calls[0][0], sqlQuery);

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -153,35 +153,57 @@ describe('pg_e2e', () => {
     exp5.$prev = null;
     expect(res5).toEqual(exp5);
 
-    // Sixth, get all users with names starting with "al" (case sensitive)
+    // Sixth, update Alan to Alain using email address
 
-    const res6 = await store.read(['users'], {
+    const res6 = await store.write(['users'], {
+      $key: { email: 'alan@acme.co' },
+      name: 'alain',
+    });
+
+    expect(res6).toEqual([
+      {
+        $key: { email: 'alan@acme.co' },
+        $ref: ['users', id2],
+      },
+      {
+        $key: id2,
+        id: id2,
+        name: 'alain',
+        email: 'alan@acme.co',
+        settings: null,
+        version: expect.any(Number),
+      },
+    ]);
+
+    // Seventh, get all users with names starting with "al" (case sensitive)
+
+    const res7 = await store.read(['users'], {
       $key: { $first: 10, name: { $re: '^al' }, $order: ['name', 'id'] },
       id: true,
       name: true,
       email: true,
     });
 
-    const exp6 = [
+    const exp7 = [
       {
         $key: {
-          $cursor: ['alan', id2],
+          $cursor: ['alain', id2],
           name: { $re: '^al' },
           $order: ['name', 'id'],
         },
         $ref: ['users', id2],
         id: id2,
-        name: 'alan',
+        name: 'alain',
         email: 'alan@acme.co',
       },
     ];
-    exp6.$page = {
+    exp7.$page = {
       $all: true,
       name: { $re: '^al' },
       $order: ['name', 'id'],
     };
-    exp6.$next = null;
-    exp6.$prev = null;
-    expect(res6).toEqual(exp6);
+    exp7.$next = null;
+    exp7.$prev = null;
+    expect(res7).toEqual(exp7);
   });
 });

--- a/src/pg/test/sql/upsert.test.js
+++ b/src/pg/test/sql/upsert.test.js
@@ -11,38 +11,104 @@ const options = {
   verCol: 'version',
 };
 
-test('put', async () => {
-  expectSql(
-    put(
-      { $put: true, id: 'post22', type: 'post', name: 'hello', email: 'world' },
-      'post22',
-      options,
-    ),
-    sql`INSERT INTO "post" ("id", "type", "name", "email", "version")
+describe('byId', () => {
+  test('put', async () => {
+    expectSql(
+      put(
+        {
+          $put: true,
+          id: 'post22',
+          type: 'post',
+          name: 'hello',
+          email: 'world',
+        },
+        'post22',
+        options,
+      ),
+      sql`INSERT INTO "post" ("id", "type", "name", "email", "version")
       VALUES (${'post22'}, ${'post'}, ${'hello'},${'world'},  ${nowTimestamp})
       ON CONFLICT ("id") DO UPDATE SET ("id", "type", "name", "email", "version")
         = (${'post22'}, ${'post'}, ${'hello'},${'world'},  ${nowTimestamp})
       RETURNING (to_jsonb("post") ||
         jsonb_build_object('$key', "id", '$ver',  ${nowTimestamp}))
     `,
-  );
-});
+    );
+  });
 
-test('patch', async () => {
-  expectSql(
-    patch(
-      { $put: true, id: 'post22', type: 'post', name: 'hello', email: 'world' },
-      'post22',
-      options,
-    ),
-    sql`UPDATE "post" SET
+  test('patch', async () => {
+    expectSql(
+      patch(
+        {
+          id: 'post22',
+          type: 'post',
+          name: 'hello',
+          email: 'world',
+        },
+        'post22',
+        options,
+      ),
+      sql`UPDATE "post" SET
         "type" = ${'post'},
         "name" = ${'hello'},
         "email" = ${'world'},
         "version" =  ${nowTimestamp}
-      WHERE "id" = ${'post22'} LIMIT 1
+      WHERE "id" = ${'post22'}
       RETURNING (to_jsonb("post") ||
         jsonb_build_object('$key', "id", '$ver', ${nowTimestamp}))
     `,
-  );
+    );
+  });
+});
+
+describe('byArg', () => {
+  test('put', async () => {
+    expectSql(
+      put(
+        {
+          $put: true,
+          id: 'post22',
+          type: 'post',
+          name: 'hello',
+          email: 'world',
+        },
+        { email: 'world' },
+        options,
+      ),
+      sql`INSERT INTO "post" ("id", "type", "name", "email", "version")
+      VALUES (${'post22'}, ${'post'}, ${'hello'},${'world'}, ${nowTimestamp})
+      ON CONFLICT ("email") DO UPDATE SET ("id", "type", "name", "email", "version")
+        = (${'post22'}, ${'post'}, ${'hello'},${'world'},  ${nowTimestamp})
+      RETURNING (to_jsonb("post") ||
+        jsonb_build_object(
+          '$key', ${'{"email":"world"}'}::jsonb,
+          '$ref', jsonb_build_array(${'post'}::text, "id"),
+          '$ver',  ${nowTimestamp}))`,
+    );
+  });
+
+  test('patch', async () => {
+    expectSql(
+      patch(
+        {
+          id: 'post22',
+          type: 'post',
+          name: 'hello',
+          email: 'world',
+        },
+        { email: 'world' },
+        options,
+      ),
+      sql`UPDATE "post" SET
+        "type" = ${'post'},
+        "name" = ${'hello'},
+        "email" = ${'world'},
+        "version" =  ${nowTimestamp}
+      WHERE "id" = (SELECT "id" FROM "post" WHERE "email" = ${'world'} LIMIT 1)
+      RETURNING (to_jsonb("post") ||
+        jsonb_build_object(
+          '$key', ${'{"email":"world"}'}::jsonb,
+          '$ref', jsonb_build_array(${'post'}::text, "id"),
+          '$ver',  ${nowTimestamp}))`,
+    );
+  });
 });


### PR DESCRIPTION
As a safety measure, update operations using arguments must only update a single item. This was implemented using invalid syntax; this update corrects it and adds test cases.