### PR TITLE
JSON columns in Postgres

### DIFF
--- a/src/common/coding/string.js
+++ b/src/common/coding/string.js
@@ -1,18 +1,5 @@
-import TextEncoderLite from 'text-encoder-lite';
-import window from 'global/window.js';
-
-if (!window.TextEncoder || !window.TextDecoder) {
-  window.TextEncoder = TextEncoderLite.TextEncoderLite;
-  window.TextDecoder = TextEncoderLite.TextDecoderLite;
-}
-
-const textEncoder = window.TextEncoder
-  ? new window.TextEncoder()
-  : new TextEncoderLite.TextEncoderLite();
-
-const textDecoder = window.TextDecoder
-  ? new window.TextDecoder('utf-8')
-  : new TextEncoderLite.TextDecoderLite('utf-8');
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder('utf-8');
 
 export function encode(string) {
   return textEncoder.encode(string);

--- a/src/common/ops/getKnown.js
+++ b/src/common/ops/getKnown.js
@@ -9,7 +9,7 @@ export default function getKnown(graph, version = 0) {
     const node = { key, version };
     if (end) {
       if (end !== key) node.end = end;
-      node.options = { subtree: true };
+      node.value = 1;
     }
     if (children) {
       node.children = getKnown(children);

--- a/src/common/ops/slice.js
+++ b/src/common/ops/slice.js
@@ -44,7 +44,7 @@ export default function slice(graph, query, root) {
         sliceRange(graph, queryNode, result);
       } else {
         const key = queryNode.key;
-        index = findFirst(graph, key, index);
+        index = findFirst(graph, key);
         // console.log('Index', graph, key, index);
         sliceNode(graph[index], queryNode, result);
       }

--- a/src/common/ops/slice.js
+++ b/src/common/ops/slice.js
@@ -11,8 +11,6 @@ import { wrap } from './path.js';
 import merge from './merge.js';
 import add from './add.js';
 
-import { format } from '@graffy/testing';
-
 class Result {
   constructor(root) {
     // When linked queries are added, they are forwarded to the root.
@@ -98,17 +96,16 @@ function sliceNode(graph, query, result) {
         ),
       );
     }
-  } else if (isBranch(graph) && query.options && query.options.subtree) {
-    // This option allows a query to say "give me the subtree under this"
-    // without knowing specifically what's available. If using this, the
-    // value of "unknown" is no longer reliable. It is intended for use in
-    // optimistic updates.
+  } else if (isBranch(graph)) {
+    // The graph is a branch and query is requesting all children here.
     result.addKnown(graph);
-  } else if (isBranch(graph) || isBranch(query)) {
-    // One side is a branch while the other is a leaf; throw error.
-    throw new Error(
-      'slice.leaf_branch_mismatch:' + format(graph) + '\n' + format(query),
+  } else if (isBranch(query)) {
+    // One graph is a leaf while the query is a leaf; return null.
+    const { known } = slice(
+      [{ key: '', end: '\uffff', version: graph.version }],
+      query.children,
     );
+    result.addKnown({ key, version: graph.version, children: known });
   } else {
     result.addKnown(graph);
   }

--- a/src/common/ops/test/getKnown.test.js
+++ b/src/common/ops/test/getKnown.test.js
@@ -18,14 +18,8 @@ test('getKnown', () => {
       key: 'foo',
       children: [
         { key: 'bar', value: 1, version: 0 },
-        {
-          key: 'bat',
-          end: 'baw',
-          value: 1,
-          version: 0,
-          options: { subtree: true },
-        },
-        { key: 'baz', value: 1, version: 0, options: { subtree: true } },
+        { key: 'bat', end: 'baw', value: 1, version: 0 },
+        { key: 'baz', value: 1, version: 0 },
       ],
       version: 0,
     },

--- a/src/common/ops/test/slice.test.js
+++ b/src/common/ops/test/slice.test.js
@@ -29,8 +29,8 @@ describe('slice', () => {
     });
   });
 
-  test('leaf_branch_mismatch', () => {
-    expect(() =>
+  test('gbranch_qleaf', () => {
+    expect(
       slice(
         [
           {
@@ -42,9 +42,51 @@ describe('slice', () => {
           },
         ],
         [{ key: 'bar', value: 1, version: 2 }],
-      ),
-    ).toThrow();
+      ).known,
+    ).toEqual([
+      {
+        key: 'bar',
+        children: [
+          { key: 'foo', value: 42, version: 3 },
+          { key: 'fuz', value: 43, version: 3 },
+        ],
+      },
+    ]);
   });
+});
+
+test('gleaf_qbranch', () => {
+  expect(
+    slice(
+      [
+        {
+          key: 'bar',
+          version: 3,
+          value: 'abc',
+        },
+      ],
+      [
+        {
+          key: 'bar',
+          value: 1,
+          children: [
+            { key: 'foo', value: 42, version: 2 },
+            { key: 'fuz', value: 43, version: 2 },
+          ],
+          version: 2,
+        },
+      ],
+    ).known,
+  ).toEqual([
+    {
+      key: 'bar',
+      version: 3,
+      children: [
+        { key: 'foo', end: 'foo', version: 3 },
+        { key: 'fuz', end: 'fuz', version: 3 },
+      ],
+    },
+  ]);
 });
 
 describe('range', () => {

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -39,9 +39,17 @@ export default class Db {
     try {
       return await this.client.query(sql);
     } catch (e) {
-      throw Error(
-        'pg.sql_error ' + e.message + ' in ' + sql.text + ' with ' + sql.values,
-      );
+      const message = [
+        e.message,
+        e.detail,
+        e.hint,
+        e.where,
+        sql.text,
+        JSON.stringify(sql.values),
+      ]
+        .filter(Boolean)
+        .join('; ');
+      throw Error('pg.sql_error ' + message);
     }
   }
 

--- a/src/pg/filter/getAst.js
+++ b/src/pg/filter/getAst.js
@@ -12,6 +12,9 @@ const valid = {
   $any: true,
   $all: true,
   $has: true,
+  $cts: true,
+  $ctd: true,
+  $ovl: true,
 };
 
 const inverse = {
@@ -38,7 +41,7 @@ export default function getAst(filter) {
 
 let counter;
 function construct(node, prop, op) {
-  if (!node || typeof node !== 'object') {
+  if (!node || typeof node !== 'object' || (prop && op)) {
     if (op && prop) return [op, prop, node];
     if (prop) return ['$eq', prop, node];
     throw Error('pgast.expected_prop_before:' + JSON.stringify(node));
@@ -72,7 +75,7 @@ function construct(node, prop, op) {
       }
       if (prop) {
         if (key[0] === '.') return construct(val, prop + key);
-        throw Error('pgast.unexpected_prop', key);
+        throw Error('pgast.unexpected_prop: ' + key);
       }
       return construct(val, key);
     }),

--- a/src/pg/sql/getArgSql.js
+++ b/src/pg/sql/getArgSql.js
@@ -23,7 +23,7 @@ export default function getArgSql(
   const lookup = (prop) => {
     const [prefix, ...suffix] = encodePath(prop);
     return suffix.length
-      ? sql`"${raw(prefix)}" #>> '{"${suffix.join('","')}"}'`
+      ? sql`"${raw(prefix)}" #> '{"${suffix.join('","')}"}'`
       : sql`"${raw(prefix)}"`;
   };
 

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -79,7 +79,7 @@ describe('pg_e2e', () => {
     exp2.$prev = null;
     expect(res2).toEqual(exp2);
 
-    // Third, upsert the same name person again with the name `Alice example`.
+    // Third, upsert the same person again.
     const res3 = await store.write(['users', { email: 'alice@acme.co' }], {
       name: 'Alicia',
       settings: { bar: 5 },
@@ -102,7 +102,7 @@ describe('pg_e2e', () => {
     const res4 = await store.write(['users', id2], {
       name: 'alan',
       email: 'alan@acme.co',
-      settings: { bar: 3 },
+      settings: { bar: 3, baz: { x: 4, y: 5 } },
       $put: true,
     });
 
@@ -110,7 +110,7 @@ describe('pg_e2e', () => {
       id: id2,
       name: 'alan',
       email: 'alan@acme.co',
-      settings: { bar: 3, $put: true },
+      settings: { bar: 3, baz: { x: 4, y: 5, $put: true }, $put: true },
       version: expect.any(Number),
     });
 
@@ -122,7 +122,7 @@ describe('pg_e2e', () => {
       id: true,
       name: true,
       email: true,
-      settings: { foo: true, bar: true },
+      settings: { foo: true, bar: true, baz: { x: true, y: true } },
     });
 
     const exp5 = [
@@ -136,7 +136,7 @@ describe('pg_e2e', () => {
         id: id1,
         name: 'Alicia',
         email: 'alice@acme.co',
-        settings: { foo: null, bar: 5 },
+        settings: { foo: null, bar: 5, baz: { x: null, y: null } },
       },
       {
         $key: {
@@ -148,7 +148,7 @@ describe('pg_e2e', () => {
         id: id2,
         name: 'alan',
         email: 'alan@acme.co',
-        settings: { foo: null, bar: 3 },
+        settings: { foo: null, bar: 3, baz: { x: 4, y: 5 } },
       },
     ];
     exp5.$page = {
@@ -165,7 +165,7 @@ describe('pg_e2e', () => {
     const res6 = await store.write(['users'], {
       $key: { email: 'alan@acme.co' },
       name: 'alain',
-      settings: { foo: 7 },
+      settings: { foo: 7, baz: { x: null, y: 8 } },
     });
 
     expect(res6).toEqual([
@@ -178,7 +178,12 @@ describe('pg_e2e', () => {
         id: id2,
         name: 'alain',
         email: 'alan@acme.co',
-        settings: { $put: true, foo: 7, bar: 3 },
+        settings: {
+          $put: true,
+          foo: 7,
+          bar: 3,
+          baz: { x: null, y: 8, $put: true },
+        },
         version: expect.any(Number),
       },
     ]);

--- a/src/pg/test/filter/getSql.test.js
+++ b/src/pg/test/filter/getSql.test.js
@@ -51,7 +51,7 @@ test('logic_inversion', () => {
 
 test('any_ovl', () => {
   expect(getSql({ tags: { $any: 'foo' } }, lookup)).toEqual(
-    sql`"tags" @@ ${['foo']}`,
+    sql`"tags" ?| ${['foo']}`,
   );
 });
 
@@ -85,6 +85,18 @@ test('all', () => {
   expect(getSql({ tags: { $all: { $gte: 'm' } } }, lookup)).toEqual(
     sql`(SELECT bool_and("el$0" >= ${'m'}) FROM UNNEST("tags") "el$0")`,
   );
+});
+
+test('cts', () => {
+  expect(
+    getSql({ emails: { $cts: { 'foo@bar.com': ['work'] } } }, lookup),
+  ).toEqual(sql`"emails" @> ${{ 'foo@bar.com': ['work'] }}`);
+});
+
+test('ctd', () => {
+  expect(
+    getSql({ emails: { $ctd: { 'foo@bar.com': ['work'] } } }, lookup),
+  ).toEqual(sql`"emails" <@ ${{ 'foo@bar.com': ['work'] }}`);
 });
 
 /*

--- a/src/pg/test/sql/clauses.test.js
+++ b/src/pg/test/sql/clauses.test.js
@@ -31,7 +31,7 @@ describe('clauses', () => {
     const query = getJsonBuildObject(data);
     expectSql(
       query,
-      sql`jsonb_build_object('a', ${data.a}, 'b', ${data.b}, 'version', ${nowTimestamp})`,
+      sql`jsonb_build_object('a', ${data.a}::jsonb, 'b', ${data.b}::jsonb, 'version', ${nowTimestamp})`,
     );
   });
 

--- a/src/pg/test/sql/upsert.test.js
+++ b/src/pg/test/sql/upsert.test.js
@@ -55,7 +55,8 @@ describe('byId', () => {
         "type" = ${'post'},
         "name" = ${'hello'},
         "email" = ${'world'},
-        "config" = "config" || ${{ foo: 3 }},
+        "config" = jsonb_strip_nulls((case jsonb_typeof("config") when 'object' then "config" else '{}'::jsonb end) ||
+          jsonb_build_object ( ${'foo'}::text , ${3}::jsonb)),
         "version" =  ${nowTimestamp}
       WHERE "id" = ${'post22'}
       RETURNING (to_jsonb("post") ||


### PR DESCRIPTION
Add support for:
- JSON merge patch (deep merge) when updating jsonb columns
- Filter conditions `$cts` and `$ctd` for jsonb columns

## Major change
No more `leaf_branch_mismatch` error. Now,
- If the query is a leaf (e.g. `settings: true`) and the graph is a branch (e.g. `settings: { darkMode: true }`), we return the whole object. With this we're moving away from strictly enforcing the "specify all the fields in the query" rule, but for efficiency reasons it is strongly recommended to continue doing so, especially on the client.
- If the query is a branch (e.g. `head: { title: true, icon: true }`) while the graph is a leaf (e.g. `head: 'My homepage'`), we return nulls: (`head: { title: null, icon: null }`). This reflects the fact that `head.title` and `head.icon` (which were requested) do not exist.
