### PR TITLE
Link and Postgres fixes

### DIFF
--- a/src/common/ops/add.js
+++ b/src/common/ops/add.js
@@ -25,8 +25,11 @@ export default function add(base, diff) {
 
     if (nodeIsBranch && itemIsBranch) {
       changed = add(item.children, node.children) || changed;
-    } else if (nodeIsBranch || itemIsBranch) {
-      throw new Error('add.branch_leaf_mismatch');
+    } else if (nodeIsBranch) {
+      continue;
+    } else if (itemIsBranch) {
+      item.value = node.value;
+      changed = true;
     } else {
       item.value += node.value;
     }

--- a/src/common/ops/path.js
+++ b/src/common/ops/path.js
@@ -27,9 +27,10 @@ export function wrap(children, path, version = 0, prefix = false) {
   return children;
 }
 
-export function unwrap(children, path) {
+export function unwrap(tree, path) {
   if (!Array.isArray(path)) throw Error('unwrap.path_not_array ' + path);
 
+  let children = tree;
   let node = { children };
   for (let i = 0; i < path.length; i++) {
     const { key } = encodeArgs(path[i]);
@@ -38,6 +39,7 @@ export function unwrap(children, path) {
     node = children[findFirst(children, key)];
     if (!node || node.key > key) return undefined; // We lack knowledge.
     if (isRange(node)) return null; // This is known to be null.
+    if (node.path) return unwrap(tree, node.path.concat(path.slice(i + 1)));
   }
 
   return getNodeValue(node);

--- a/src/common/ops/step.js
+++ b/src/common/ops/step.js
@@ -27,7 +27,7 @@ export function keyBefore(key) {
 }
 
 export function keyAfter(key) {
-  if (key === '' || key === '\uffff' || key === '\0' || key === '\0\uffff') {
+  if (key === '\uffff' || key === '\0' || key === '\0\uffff') {
     return key;
   }
   const l = key.length - 1;

--- a/src/fill/index.js
+++ b/src/fill/index.js
@@ -1,6 +1,5 @@
 import { merge, slice } from '@graffy/common';
 import subscribe from './subscribe.js';
-// import { format } from '@graffy/testing';
 import debug from 'debug';
 
 const log = debug('graffy:fill');
@@ -32,7 +31,7 @@ export default function fill(_) {
       }
 
       if (!budget) {
-        log('fill.max_recursion', value, query);
+        log('fill.max_recursion', slice(value, query).unknown);
         throw new Error('fill.max_recursion');
       }
       // console.log('Read', debug(query), 'returned', debug(value));

--- a/src/link/index.js
+++ b/src/link/index.js
@@ -20,6 +20,7 @@ export default (defs) => (store) => {
     if (!usedDefs.length) return next(query, options);
 
     const result = await next(wrap(unwrappedQuery, prefix), options);
+    const version = result[0].version;
     const unwrappedResult = unwrap(result, prefix);
 
     // PrepQueryLinks have removed the parts of the query that are
@@ -28,12 +29,12 @@ export default (defs) => (store) => {
     add(unwrappedQuery, unwrap(query, prefix));
 
     log('finalizing', prefix, unwrappedQuery);
-    const finalizedResult = finalize(unwrappedResult, unwrappedQuery);
+    const finalizedResult = finalize(unwrappedResult, unwrappedQuery, version);
 
-    log('beforeAddingLinks', prefix, unwrappedResult);
-
+    log('beforeAddingLinks', prefix, finalizedResult);
     linkGraph(finalizedResult, usedDefs);
-    return wrap(finalizedResult, prefix);
+    log('afterAddingLinks', prefix, finalizedResult);
+    return wrap(finalizedResult, prefix, version);
   });
 };
 

--- a/src/link/index.js
+++ b/src/link/index.js
@@ -1,6 +1,9 @@
-import { wrap, unwrap } from '@graffy/common';
+import { wrap, unwrap, finalize, add } from '@graffy/common';
 import linkGraph from './linkGraph.js';
 import prepQueryLinks from './prepQueryLinks.js';
+import debug from 'debug';
+
+const log = debug('graffy:link');
 
 export default (defs) => (store) => {
   const prefix = store.path;
@@ -13,12 +16,24 @@ export default (defs) => (store) => {
     const unwrappedQuery = clone(unwrap(query, prefix));
     const usedDefs = prepQueryLinks(unwrappedQuery, defEntries);
 
+    // Shortcut for queries that don't interact with any links
+    if (!usedDefs.length) return next(query, options);
+
     const result = await next(wrap(unwrappedQuery, prefix), options);
     const unwrappedResult = unwrap(result, prefix);
 
-    // unwrappedResult is still "inside" result and will be modified:
-    linkGraph(unwrappedResult, usedDefs);
-    return result;
+    // PrepQueryLinks have removed the parts of the query that are
+    // provided by links, so the result would not have "finalized"
+    // them.
+    add(unwrappedQuery, unwrap(query, prefix));
+
+    log('finalizing', prefix, unwrappedQuery);
+    const finalizedResult = finalize(unwrappedResult, unwrappedQuery);
+
+    log('beforeAddingLinks', prefix, unwrappedResult);
+
+    linkGraph(finalizedResult, usedDefs);
+    return wrap(finalizedResult, prefix);
   });
 };
 

--- a/src/link/link.test.js
+++ b/src/link/link.test.js
@@ -14,6 +14,7 @@ describe('link', () => {
       link({
         'post.$pid.author': ['user', '$$post.$pid.authorId'],
         'user.$uid.posts': ['post', { $all: true, authorId: '$uid' }],
+        'user.$uid.friends.$i': ['user', '$$user.$uid.friendIds.$i'],
       }),
     );
     store.use(backend.middleware);
@@ -24,6 +25,7 @@ describe('link', () => {
         user: {
           ali: { name: 'Alicia' },
           bob: { name: 'Robert' },
+          carl: { name: 'Carl', friendIds: ['ali', 'bob'] },
         },
         post: [
           { $key: 'p01', title: 'Post 1 A', authorId: 'ali' },
@@ -169,6 +171,19 @@ describe('link', () => {
     exp.$next = { $first: 1, authorId: 'bob', $after: { id: 'p02' } };
     exp.$prev = null;
 
+    expect(res).toEqual(exp);
+  });
+
+  test('parallel_links', async () => {
+    const res = await store.read(['user', 'carl'], {
+      name: true,
+      friends: { $key: { $all: true }, name: true },
+    });
+    console.log(res);
+    const exp = {
+      name: 'Carl',
+      friends: [{ name: 'Alicia' }, { name: 'Robert ' }],
+    };
     expect(res).toEqual(exp);
   });
 });

--- a/src/link/link.test.js
+++ b/src/link/link.test.js
@@ -1,4 +1,5 @@
 import Graffy from '@graffy/core';
+import fill from '@graffy/fill';
 import { encodeGraph, encodeQuery } from '@graffy/common';
 import { mockBackend } from '@graffy/testing';
 import link from './index.js';
@@ -8,6 +9,7 @@ describe('link', () => {
 
   beforeEach(() => {
     store = new Graffy();
+    store.use(fill());
     backend = mockBackend();
     backend.read = jest.fn(backend.read);
     store.use(
@@ -136,7 +138,7 @@ describe('link', () => {
   });
 
   test('read_with_page_args', async () => {
-    const res = await store.read('post', [
+    const resPromise = store.read('post', [
       {
         $key: { $first: 1, authorId: 'bob' },
         title: true,
@@ -155,6 +157,10 @@ describe('link', () => {
       {},
       expect.any(Function),
     );
+
+    // We do this because the query that backend.read is called with
+    // is modified afterwards.
+    const res = await resPromise;
 
     const exp = [
       {

--- a/src/link/link.test.js
+++ b/src/link/link.test.js
@@ -179,11 +179,17 @@ describe('link', () => {
       name: true,
       friends: { $key: { $all: true }, name: true },
     });
-    console.log(res);
+    // console.log(res);
     const exp = {
       name: 'Carl',
-      friends: [{ name: 'Alicia' }, { name: 'Robert ' }],
+      friends: [
+        { $key: 0, $ref: ['user', 'ali'], name: 'Alicia' },
+        { $key: 1, $ref: ['user', 'bob'], name: 'Robert' },
+      ],
     };
+    exp.friends.$page = { $all: true };
+    exp.friends.$prev = null;
+    exp.friends.$next = null;
     expect(res).toEqual(exp);
   });
 });

--- a/src/link/linkGraph.js
+++ b/src/link/linkGraph.js
@@ -1,99 +1,172 @@
-import { merge, unwrap, findFirst, encodePath, splitRef } from '@graffy/common';
+import {
+  merge,
+  wrap,
+  unwrap,
+  findFirst,
+  encodePath,
+  splitRef,
+} from '@graffy/common';
 
-/* Adds links to a graph, using the provided link definitions.
-   Modifies the graph in-place. */
 export default function linkGraph(rootGraph, defs) {
-  for (const { path, def } of defs) linkGraphDef(rootGraph, path, def);
-  // console.log('linked', rootGraph);
-  return rootGraph;
+  let version = rootGraph[0].version;
 
-  function findChildren(node) {
-    if (node.children) return node.children;
-    if (node.path) {
-      const linkedNode = unwrap(rootGraph, node.path);
-      if (Array.isArray(linkedNode)) return linkedNode;
+  for (const { path, def } of defs) {
+    /** @type {{
+        value: any,
+        vars: Record<string, any>,
+        reqs: Record<string, true>,
+      }[][]} */
+    const braid = def.map(getKeyValues);
+    const strands = unbraid(braid);
+
+    const pathReqs = path
+      .filter((key) => key[0] === '$')
+      .reduce((acc, key) => {
+        acc[key.slice(1)] = true;
+        return acc;
+      }, {});
+
+    outer: for (const { value, vars, reqs } of strands) {
+      for (const req in reqs) if (!(req in vars)) continue outer;
+      for (const req in pathReqs) if (!(req in vars)) continue outer;
+
+      const realPath = makeRef(path, vars);
+      const realRef = makeRef(value, vars);
+      const node = { key: realPath.pop(), path: encodePath(realRef), version };
+
+      const [range] = splitRef(realRef);
+      if (range) node.prefix = true;
+
+      let target = rootGraph;
+      do {
+        const key = realPath.shift();
+        const nextTarget = target[findFirst(target, key)];
+        if (!nextTarget || nextTarget.key !== key || nextTarget.end) {
+          realPath.unshift(key);
+          break;
+        }
+        target = nextTarget.path
+          ? unwrap(rootGraph, nextTarget.path)
+          : nextTarget.children;
+      } while (target && realPath.length);
+
+      if (!target) return;
+      merge(target, realPath.length ? wrap([node], realPath, version) : [node]);
     }
-    throw Error('link.no_children ' + JSON.stringify(node));
   }
 
-  // TODO: Write a linkGraphDef that traverses using *def*, then makes
-  // refs at the corresponding path.
+  // console.log(rootGraph);
+  return rootGraph;
 
-  function linkGraphDef(graph, path, def, vars = {}, version = 0) {
+  function getKeyValues(key) {
+    if (typeof key === 'string' && key[0] === '$' && key[1] === '$') {
+      return lookupValues(rootGraph, key.slice(2).split('.'));
+    }
+    if (Array.isArray(key)) {
+      return unbraid(key.map(getKeyValues));
+    }
+    if (typeof key === 'object' && key) {
+      const values = unbraid(Object.values(key).map(getKeyValues));
+      const keys = Object.keys(key);
+
+      return values.map(({ value, vars, reqs }) => ({
+        value: value.reduce((acc, val, i) => {
+          acc[keys[i]] = val;
+          return acc;
+        }, {}),
+        vars,
+        reqs,
+      }));
+    }
+    if (typeof key === 'string' && key[0] === '$') {
+      return [{ value: key, vars: {}, reqs: { [key.slice(1)]: true } }];
+    }
+    return [{ value: key, vars: {}, reqs: {} }];
+  }
+
+  /**
+    Takes a lookup expression which may optionally contain named placeholders,
+    and returns an array of possible values in the graph that it matches.
+    For each such value, it also returns the corresponding placeholder values.
+    @param {string[]} path
+    @return {{ value: any, vars: Record<string,any> }[]}
+  */
+  function lookupValues(graph, path, vars = {}) {
     const [key, ...rest] = path;
 
-    console.log('lGD', { key });
-
-    function addRef(k) {
-      const ref = makeRef(def, vars);
-      const [range] = splitRef(def);
-      const node = { key: k, path: encodePath(ref), version };
-      if (range) node.prefix = true;
-      merge(graph, [node]);
-      return;
-    }
-
-    if (rest.length === 0) {
-      if (key[0] === '$') {
-        for (const node of graph) {
-          if (node.end) continue;
-          console.log('Linking', key, node.key);
-          vars[key.slice(1)] = node.key;
-          addRef(node.key);
-        }
-      } else {
-        addRef(key);
-      }
-    }
-
     if (key[0] === '$') {
-      for (const node of graph) {
-        if (node.end) continue;
+      return graph.flatMap((node) => {
+        if (node.end) return [];
         const newVars = { ...vars, [key.slice(1)]: node.key };
-        linkGraphDef(findChildren(node), rest, def, newVars, node.version);
-      }
-      return;
+        return recurse(node, rest, newVars);
+      });
     }
 
     let node = graph[findFirst(graph, key)];
-
-    if (!node || node.key !== key || node.end) {
-      // We want to add a branch node with no children (yet).
-      // Unfortunately merge does not like this, and we have
-      // to work around it by inserting a leaf node and then
-      // converting it to a branch.
-      node = { key, version, value: 1 };
-      merge(graph, [node]);
-      delete node.value;
-      node.children = [];
-    }
-    return linkGraphDef(findChildren(node), rest, def, vars, node.version);
+    if (!node || node.key !== key || node.end) return [];
+    return recurse(node, rest, vars);
   }
 
-  // If you find yourself editing this function, you probably want
-  // to edit prepareDef in prepQueryLinks too.
-  function makeRef(def, vars) {
-    function getValue(key) {
-      if (typeof key !== 'string') return key;
-      return key[0] === '$' ? vars[key.slice(1)] : key;
+  function recurse(node, path, vars) {
+    if (!path.length) return [{ value: node.value, vars, reqs: {} }];
+    if (node.children) return lookupValues(node.children, path, vars);
+    if (node.path) {
+      const linked = unwrap(rootGraph, node.path);
+      if (Array.isArray(linked)) return lookupValues(linked, path, vars);
     }
-
-    function replacePlaceholders(key) {
-      if (typeof key === 'string' && key[0] === '$' && key[1] === '$') {
-        return unwrap(rootGraph, key.slice(2).split('.').map(getValue));
-      }
-      if (Array.isArray(key)) {
-        return key.map(replacePlaceholders);
-      }
-      if (typeof key === 'object' && key) {
-        const result = {};
-        for (const prop in key) result[prop] = replacePlaceholders(key[prop]);
-        return result;
-      }
-      return key;
-    }
-
-    const ref = def.map(replacePlaceholders);
-    return ref;
+    throw Error('link.no_children ' + JSON.stringify(node));
   }
+}
+
+function unbraid(braid) {
+  const [options, ...rest] = braid;
+  if (!rest.length) {
+    return options.map((option) => ({
+      value: [option.value],
+      vars: option.vars,
+      reqs: option.reqs,
+    }));
+  }
+
+  const strands = unbraid(rest);
+  return options.flatMap((option) =>
+    strands
+      .filter((strand) => isCompatible(option.vars, strand.vars))
+      .map((strand) => ({
+        value: [option.value, ...strand.value],
+        vars: { ...option.vars, ...strand.vars },
+        reqs: { ...option.reqs, ...strand.reqs },
+      })),
+  );
+}
+
+function isCompatible(oVars, sVars) {
+  for (const name in oVars) {
+    if (name in sVars && oVars[name] !== sVars[name]) return false;
+  }
+  return true;
+}
+
+// If you find yourself editing this function, you probably want
+// to edit prepareDef in prepQueryLinks too.
+function makeRef(def, vars) {
+  function getValue(key) {
+    if (typeof key !== 'string') return key;
+    return key[0] === '$' ? vars[key.slice(1)] : key;
+  }
+
+  function replacePlaceholders(key) {
+    if (Array.isArray(key)) {
+      return key.map(replacePlaceholders);
+    }
+    if (typeof key === 'object' && key) {
+      const result = {};
+      for (const prop in key) result[prop] = replacePlaceholders(key[prop]);
+      return result;
+    }
+    return getValue(key);
+  }
+
+  const ref = def.map(replacePlaceholders);
+  return ref;
 }

--- a/src/link/linkGraph.test.js
+++ b/src/link/linkGraph.test.js
@@ -1,0 +1,78 @@
+import { encodeGraph } from '../common/index.js';
+import linkGraph from './linkGraph.js';
+
+test('simple', () => {
+  const graph = encodeGraph(
+    {
+      user: {
+        bob: {
+          friendIds: ['ali', 'carl'],
+        },
+      },
+    },
+    0,
+  );
+
+  const defs = [
+    {
+      path: ['user', '$i', 'friends', '$j'],
+      def: ['user', '$$user.$i.friendIds.$j'],
+    },
+  ];
+  expect(linkGraph(graph, defs)).toEqual(
+    encodeGraph(
+      {
+        user: {
+          bob: {
+            friendIds: ['ali', 'carl'],
+            friends: [
+              { $key: 0, $ref: ['user', 'ali'] },
+              { $key: 1, $ref: ['user', 'carl'] },
+            ],
+          },
+        },
+      },
+      0,
+    ),
+  );
+});
+
+test.skip('complex', () => {
+  const graph = encodeGraph(
+    {
+      foo: [
+        { $key: 'two', x: 30 },
+        { $key: 'three', x: 33 },
+      ],
+    },
+    0,
+  );
+
+  const defs = [
+    {
+      path: ['bar', '$n', 'x'],
+      def: ['baz', '$$foo.$n.x', { number: '$n', $all: true }],
+    },
+  ];
+  expect(linkGraph(graph, defs)).toEqual(
+    encodeGraph(
+      {
+        foo: [
+          { $key: 'two', x: 30 },
+          { $key: 'three', x: 33 },
+        ],
+        bar: [
+          {
+            $key: 'two',
+            x: { $ref: ['baz', 30, { number: 'two', $all: true }] },
+          },
+          {
+            $key: 'three',
+            x: { $ref: ['baz', 33, { number: 'three', $all: true }] },
+          },
+        ],
+      },
+      0,
+    ),
+  );
+});

--- a/src/link/prepQueryLinks.test.js
+++ b/src/link/prepQueryLinks.test.js
@@ -54,3 +54,38 @@ test('prepQueryLinks', () => {
     },
   ]);
 });
+
+test('parallelLookups', () => {
+  const defs = [
+    {
+      path: ['foo', 'bars', '$i'],
+      def: ['bar', '$$foo.barIds.$i'],
+    },
+  ];
+
+  const query = encodeQuery({
+    foo: {
+      bars: {
+        $key: { $first: 10 },
+        prop: true,
+      },
+    },
+  });
+
+  const usedDefs = prepQueryLinks(query, defs);
+
+  expect(query).toEqual(
+    encodeQuery({
+      foo: {
+        barIds: { $key: { $first: 10 } },
+      },
+    }),
+  );
+
+  expect(usedDefs).toEqual([
+    {
+      path: ['foo', 'bars', '$i'],
+      def: ['bar', '$$foo.barIds.$i'],
+    },
+  ]);
+});

--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -29,13 +29,6 @@ export const lookup = (prop) => {
     : sql`"${raw(prefix)}"`;
 };
 
-// export const getType = (prop) => {
-//   const [_prefix, ...suffix] = encodePath(prop);
-//   // TODO: Get the actual type using the information_schema
-//   // and initialization time and stop using any.
-//   return suffix.length ? 'jsonb' : 'any';
-// };
-
 const aggSql = {
   $sum: (prop) => sql`sum((${lookup(prop)})::numeric)`,
   $card: (prop) => sql`count(distinct(${lookup(prop)}))`,

--- a/src/pg/sql/getArgSql.js
+++ b/src/pg/sql/getArgSql.js
@@ -2,7 +2,7 @@ import sql, { join } from 'sql-template-tag';
 import { isEmpty } from '@graffy/common';
 import { getFilterSql } from '../filter/index.js';
 import { getArgMeta, getAggMeta } from './getMeta';
-import { getJsonBuildObject, lookup } from './clauses.js';
+import { getJsonBuildTrusted, lookup } from './clauses.js';
 
 /**
   Uses the args object (typically passed in the $key attribute)
@@ -59,9 +59,9 @@ export default function getArgSql(
 
   const orderQuery =
     $order &&
-    getJsonBuildObject({ $order: sql`${JSON.stringify($order)}::jsonb` });
+    getJsonBuildTrusted({ $order: sql`${JSON.stringify($order)}::jsonb` });
 
-  const cursorQuery = getJsonBuildObject({
+  const cursorQuery = getJsonBuildTrusted({
     $cursor: sql`jsonb_build_array(${join(groupCols || orderCols)})`,
   });
 

--- a/src/pg/sql/getMeta.js
+++ b/src/pg/sql/getMeta.js
@@ -1,14 +1,14 @@
 import sql, { join, raw } from 'sql-template-tag';
-import { getJsonBuildObject, nowTimestamp } from './clauses';
+import { getJsonBuildTrusted, nowTimestamp } from './clauses';
 
 export const getIdMeta = ({ idCol }) =>
-  getJsonBuildObject({
+  getJsonBuildTrusted({
     $key: sql`"${raw(idCol)}"`,
     $ver: nowTimestamp,
   });
 
 export const getArgMeta = (key, prefix, idCol) =>
-  getJsonBuildObject({
+  getJsonBuildTrusted({
     $key: key,
     $ref: sql`jsonb_build_array(${join(
       prefix.map((k) => sql`${k}::text`),
@@ -17,7 +17,7 @@ export const getArgMeta = (key, prefix, idCol) =>
   });
 
 export const getAggMeta = (key, $group) =>
-  getJsonBuildObject({
-    $key: join([key, getJsonBuildObject({ $group })].filter(Boolean), ' || '),
+  getJsonBuildTrusted({
+    $key: join([key, getJsonBuildTrusted({ $group })].filter(Boolean), ' || '),
     $ver: nowTimestamp,
   });

--- a/src/pg/sql/upsert.js
+++ b/src/pg/sql/upsert.js
@@ -4,7 +4,7 @@ import getArgSql from './getArgSql.js';
 import { getIdMeta } from './getMeta.js';
 import {
   getInsert,
-  getJsonBuildObject,
+  getJsonBuildTrusted,
   getSelectCols,
   getUpdates,
 } from './clauses.js';
@@ -73,5 +73,5 @@ export function del(arg, options) {
   return sql`
     DELETE FROM "${raw(table)}"
     WHERE ${where}
-    RETURNING (${getJsonBuildObject({ $key: arg })})`;
+    RETURNING (${getJsonBuildTrusted({ $key: arg })})`;
 }

--- a/src/pg/test/filter/getSql.test.js
+++ b/src/pg/test/filter/getSql.test.js
@@ -69,3 +69,9 @@ test('ctd', () => {
     sql`"emails" <@ ${JSON.stringify({ 'foo@bar.com': ['work'] })}::jsonb`,
   );
 });
+
+test('regex', () => {
+  expect(
+    getSql({ 'data.Name': { $re: 'abc' } }, opt({ data: 'jsonb' })),
+  ).toEqual(sql`("data" #> ${['Name']})::text ~ ${'abc'}`);
+});

--- a/src/pg/test/sql/clauses.test.js
+++ b/src/pg/test/sql/clauses.test.js
@@ -4,7 +4,7 @@ import {
   getInsert,
   getUpdates,
   nowTimestamp,
-  getJsonBuildObject,
+  getJsonBuildTrusted,
   getSelectCols,
 } from '../../sql/clauses';
 
@@ -35,7 +35,7 @@ describe('clauses', () => {
 
   test('jsonBuildObject', () => {
     const data = { a: 1, b: 2, version: nowTimestamp };
-    const query = getJsonBuildObject(data);
+    const query = getJsonBuildTrusted(data);
     expectSql(
       query,
       sql`jsonb_build_object('a', ${'1'}::jsonb, 'b', ${'2'}::jsonb, 'version', ${nowTimestamp})`,

--- a/src/server/httpServer.js
+++ b/src/server/httpServer.js
@@ -48,7 +48,8 @@ export default function server(store) {
           throw Error('httpServer.get_unsupported');
         }
       } catch (e) {
-        log(e);
+        log(e.message);
+        log(e.stack);
         res.writeHead(400);
         res.end(`${e.message}`);
       }
@@ -66,6 +67,8 @@ export default function server(store) {
         res.writeHead(200);
         res.end(serialize(value));
       } catch (e) {
+        log(e.message);
+        log(e.stack);
         res.writeHead(400);
         res.end(`${e.message}`);
       }

--- a/src/testing/mockBackend.js
+++ b/src/testing/mockBackend.js
@@ -1,4 +1,4 @@
-import { merge, makeWatcher } from '@graffy/common';
+import { merge, makeWatcher, slice } from '@graffy/common';
 // import debug from 'debug';
 
 // const log = debug('graffy:mockBackend');
@@ -9,7 +9,7 @@ export default function mockBackend(options = {}) {
 
   const backend = {
     state,
-    read: () => state,
+    read: (query) => slice(state, query).known,
     watch: () => watcher.watch(options.liveQuery ? state : undefined),
     write: (change) => {
       // change = setVersion(change, Date.now());


### PR DESCRIPTION
Fixes several issues:
- Link: `$foo` markers now correctly match and replace pagination keys, allowing links to be used with pagination.
- Pg: Updating JSONB columns with an array at the root now works correctly.
- Pg: Cast the left-hand-side expression to text when used in a $re or $ire operation