### PR TITLE
(pg) Use the default expression on the version column

### DIFF
--- a/src/common/coding/decodeTree.js
+++ b/src/common/coding/decodeTree.js
@@ -79,7 +79,7 @@ function decode(nodes = [], { isGraph } = {}) {
           // prettier-ignore
           collection[$key] = (
             isDef($val) ? $val :
-            !isEmpty(item) ? item :
+            !isEmpty(item) || item.$ref || item.$put ? item :
             isGraph ? null : true
           );
           return collection;
@@ -116,7 +116,9 @@ function decode(nodes = [], { isGraph } = {}) {
         throw Error('decode.unencoded_prefix_ref: ' + node.path);
       }
       lastKey.$all = true;
-      return [{ $key: args, $ref }];
+      const linkObject = { $key: args };
+      Object.defineProperty(linkObject, '$ref', { value: $ref });
+      return [linkObject];
     }
 
     const children = decodeChildren(node.children);
@@ -159,7 +161,9 @@ function decode(nodes = [], { isGraph } = {}) {
   }
 
   function decodeLinkNode(node) {
-    return { $key: decodeArgs(node), $ref: decodePath(node.path) };
+    const linkObject = { $key: decodeArgs(node) };
+    Object.defineProperty(linkObject, '$ref', { value: decodePath(node.path) });
+    return linkObject;
   }
 
   return decodeChildren(nodes);

--- a/src/common/coding/decodeTree.js
+++ b/src/common/coding/decodeTree.js
@@ -5,8 +5,8 @@ import { keyAfter } from '../ops/index.js';
 import { isRange, isBranch, isPrefix, isLink } from '../node/index.js';
 
 /**
-  @param {Tree} node
-  @param {boolean} options.isGraph
+  @param {any[]} nodes
+  @param {{ isGraph?: boolean }} options
 */
 function decode(nodes = [], { isGraph } = {}) {
   function decodeChildren(nodes) {
@@ -73,7 +73,9 @@ function decode(nodes = [], { isGraph } = {}) {
           delete item.$key;
           delete item.$val;
 
-          if (typeof $val === 'object') $val.$val = true;
+          if (typeof $val === 'object') {
+            Object.defineProperty($val, '$val', { value: true });
+          }
           // prettier-ignore
           collection[$key] = (
             isDef($val) ? $val :

--- a/src/common/coding/decorate.js
+++ b/src/common/coding/decorate.js
@@ -36,7 +36,7 @@ export default function decorate(rootGraph, rootQuery) {
         targetPlumGraph,
         range ? { $key: range, ...props } : props,
       );
-      graph.$ref = $ref;
+      Object.defineProperty(graph, '$ref', { value: $ref });
     } else if (Array.isArray(query)) {
       let pageKey;
       graph = query.flatMap((item, i) => {
@@ -99,7 +99,9 @@ export default function decorate(rootGraph, rootQuery) {
       }
     }
 
-    if (plumGraph[REF]) graph.$ref = decodePath(plumGraph[REF]);
+    if (plumGraph[REF]) {
+      Object.defineProperty(graph, '$ref', decodePath(plumGraph[REF]));
+    }
     return graph;
   }
 

--- a/src/common/coding/encodeTree.js
+++ b/src/common/coding/encodeTree.js
@@ -6,7 +6,7 @@ import { merge, add, wrap, finalize } from '../ops/index.js';
 const ROOT_KEY = Symbol();
 
 /**
-  @param {InTree} value
+  @param {any} value
   @param {{version?: number, isGraph?: boolean}} options
 */
 function encode(value, { version, isGraph } = {}) {
@@ -37,8 +37,7 @@ function encode(value, { version, isGraph } = {}) {
     if (!isDef(object)) return;
     if (typeof object === 'object' && object && isEmpty(object)) return;
 
-    const { $key, $ver, ...data } = object || {};
-    const { $ref, $val, $chi, $put, ...props } = data;
+    const { $key, $ver, $ref, $val, $chi, $put, ...props } = object || {};
 
     if (isDef($ver)) ver = $ver;
 
@@ -65,7 +64,12 @@ function encode(value, { version, isGraph } = {}) {
         then add the "prefix" flag to the node.
       */
 
-      if (isGraph && page && !isDef(page.$cursor) && !isEmpty(data)) {
+      if (
+        isGraph &&
+        page &&
+        !isDef(page.$cursor) &&
+        ($ref || $val || $chi || $put || !isEmpty(props))
+      ) {
         // console.log('here');
         const node = makeNode({ ...object, $key: filter || '' }, key, ver);
         // if (!node) console.log(object, filter, key);

--- a/src/common/coding/test/decodeGraph.test.js
+++ b/src/common/coding/test/decodeGraph.test.js
@@ -1,6 +1,7 @@
 import { decodeGraph } from '../decodeTree.js';
 import { encode as key } from '../struct.js';
 import { keyAfter, keyBefore } from '../../ops/index.js';
+import { ref, keyref } from '@graffy/testing';
 
 const val = (obj) => {
   Object.defineProperty(obj, '$val', { value: true });
@@ -48,14 +49,14 @@ test('decodeGraph', () => {
         title: '1984',
         body: 'Lorem ipsum',
         options: val({ inStock: true }),
-        author: { $ref: ['users', '1'] },
+        author: ref(['users', '1']),
       },
       {
         $key: { title: '2001' },
         title: '2001',
         body: 'Hello world',
         options: val({ borrowed: true }),
-        author: { $ref: ['users', '2'] },
+        author: ref(['users', '2']),
       },
     ],
   };
@@ -125,10 +126,10 @@ test('rangeRef', () => {
   // console.log(JSON.stringify(result));
   expect(result).toEqual({
     foo: [
-      {
-        $key: { $all: true, tag: 'x' },
-        $ref: ['bar', { $all: true, tag: 'x', id: 'y' }],
-      },
+      keyref({ $all: true, tag: 'x' }, [
+        'bar',
+        { $all: true, tag: 'x', id: 'y' },
+      ]),
     ],
   });
 });

--- a/src/common/coding/test/decodeGraph.test.js
+++ b/src/common/coding/test/decodeGraph.test.js
@@ -2,6 +2,11 @@ import { decodeGraph } from '../decodeTree.js';
 import { encode as key } from '../struct.js';
 import { keyAfter, keyBefore } from '../../ops/index.js';
 
+const val = (obj) => {
+  Object.defineProperty(obj, '$val', { value: true });
+  return obj;
+};
+
 test('decodeGraph', () => {
   const decodedGraph = decodeGraph(
     /* prettier-ignore */
@@ -42,14 +47,14 @@ test('decodeGraph', () => {
         $key: { title: '1984' },
         title: '1984',
         body: 'Lorem ipsum',
-        options: { inStock: true, $val: true },
+        options: val({ inStock: true }),
         author: { $ref: ['users', '1'] },
       },
       {
         $key: { title: '2001' },
         title: '2001',
         body: 'Hello world',
-        options: { borrowed: true, $val: true },
+        options: val({ borrowed: true }),
         author: { $ref: ['users', '2'] },
       },
     ],

--- a/src/common/coding/test/decorate.test.js
+++ b/src/common/coding/test/decorate.test.js
@@ -1,6 +1,11 @@
 import decorate from '../decorate.js';
 import { encodeGraph } from '../encodeTree.js';
 
+const ref = (ref, obj) => {
+  Object.defineProperty(obj, '$ref', { value: ref });
+  return obj;
+};
+
 describe('references', () => {
   test('point', () => {
     const result = decorate(
@@ -12,7 +17,7 @@ describe('references', () => {
     );
 
     expect(result).toEqual({
-      foo: { $ref: ['bar'], baz: 10 },
+      foo: ref(['bar'], { baz: 10 }),
     });
   });
 });
@@ -131,14 +136,16 @@ test.skip('arrayCursor.decode', () => {
 });
 
 test('alias', () => {
-  const expectedArray = [
-    { x: 100, $key: { t: 3, $cursor: 1 } },
-    { x: 200, $key: { t: 3, $cursor: 2 } },
-  ];
+  const expectedArray = ref(
+    ['foo', { t: 3, $first: 2 }],
+    [
+      { x: 100, $key: { t: 3, $cursor: 1 } },
+      { x: 200, $key: { t: 3, $cursor: 2 } },
+    ],
+  );
   expectedArray.$page = { $all: true, $until: 2 };
   expectedArray.$next = { $first: 2, $after: 2 };
   expectedArray.$prev = null;
-  expectedArray.$ref = ['foo', { t: 3, $first: 2 }];
 
   const result = decorate(
     [

--- a/src/core/test/porcelain.test.js
+++ b/src/core/test/porcelain.test.js
@@ -1,5 +1,6 @@
 import Graffy from '../Graffy.js';
 import GraffyFill from '@graffy/fill';
+import { ref } from '@graffy/testing';
 
 test('Porcelain read', async () => {
   const store = new Graffy();
@@ -41,12 +42,12 @@ test('Porcelain read', async () => {
     {
       $key: ['1984'],
       title: '1984',
-      author: { $ref: ['users', 'orwell'], name: 'George Orwell' },
+      author: ref(['users', 'orwell'], { name: 'George Orwell' }),
     },
     {
       $key: ['2001'],
       title: '2001',
-      author: { $ref: ['users', 'clarke'], name: 'Arthur C Clarke' },
+      author: ref(['users', 'clarke'], { name: 'Arthur C Clarke' }),
     },
   ];
   expectedResult.$page = { $all: true, $until: ['2001'] };
@@ -107,12 +108,12 @@ test('Porcelain subscription', async () => {
     {
       $key: ['1984'],
       title: '1984',
-      author: { $ref: ['users', 'orwell'], name: 'George Orwell' },
+      author: ref(['users', 'orwell'], { name: 'George Orwell' }),
     },
     {
       $key: ['2001'],
       title: '2001',
-      author: { $ref: ['users', 'clarke'], name: 'Arthur C Clarke' },
+      author: ref(['users', 'clarke'], { name: 'Arthur C Clarke' }),
     },
   ];
   expectedResult.$page = { $all: true, $until: ['2001'] };

--- a/src/core/test/porcelain.test.js
+++ b/src/core/test/porcelain.test.js
@@ -128,7 +128,7 @@ test('write array value', async () => {
 
   const provider = jest.fn((change) => {
     const expected = ['hello', 'world'];
-    expected.$val = true;
+    Object.defineProperty(expected, '$val', { value: true });
     expect(change).toEqual({ foo: expected });
     return { foo: { $val: ['hello', 'world'] } };
   });

--- a/src/core/test/read.test.js
+++ b/src/core/test/read.test.js
@@ -1,5 +1,6 @@
 import Graffy from '../Graffy.js';
 import fill from '@graffy/fill';
+import { ref } from '@graffy/testing';
 
 let g;
 beforeEach(() => {
@@ -225,7 +226,7 @@ describe('link', () => {
 
   test('friendly', async () => {
     expect(await g.read({ foo: { x: { baz: 1 } } })).toEqual({
-      foo: { x: { $ref: ['bar'], baz: 3 } },
+      foo: { x: ref(['bar'], { baz: 3 }) },
     });
   });
 });
@@ -234,7 +235,7 @@ describe('alias', () => {
   test('simple', async () => {
     g.onRead('foo', () => ({ x: 100 }));
     expect(await g.read({ bar: { $ref: ['foo'], x: 1 } })).toEqual({
-      bar: { $ref: ['foo'], x: 100 },
+      bar: ref(['foo'], { x: 100 }),
     });
   });
 
@@ -247,14 +248,16 @@ describe('alias', () => {
     const result = await g.read({
       bar: { $ref: ['foo', { t: 3, $first: 2 }], x: 1 },
     });
-    const expectedArray = [
-      { $key: { t: 3, $cursor: 1 }, x: 100 },
-      { $key: { t: 3, $cursor: 2 }, x: 200 },
-    ];
+    const expectedArray = ref(
+      ['foo', { t: 3, $first: 2 }],
+      [
+        { $key: { t: 3, $cursor: 1 }, x: 100 },
+        { $key: { t: 3, $cursor: 2 }, x: 200 },
+      ],
+    );
     expectedArray.$page = { $all: true, $until: 2 };
     expectedArray.$next = { $first: 2, $after: 2 };
     expectedArray.$prev = null;
-    expectedArray.$ref = ['foo', { t: 3, $first: 2 }];
 
     expect(result).toEqual({
       bar: expectedArray,

--- a/src/core/test/ref.test.js
+++ b/src/core/test/ref.test.js
@@ -1,7 +1,7 @@
 import Graffy from '../Graffy.js';
 import fill from '@graffy/fill';
-
 import { splitArgs } from '@graffy/common';
+import { put, ref } from '@graffy/testing';
 
 describe('ref', () => {
   describe('author', () => {
@@ -45,7 +45,7 @@ describe('ref', () => {
         posts: {
           abc: {
             title: 'Title abc',
-            author: { $ref: ['users', 'uabc'], name: 'User uabc' },
+            author: ref(['users', 'uabc'], { name: 'User uabc' }),
           },
         },
       };
@@ -66,7 +66,7 @@ describe('ref', () => {
         },
       });
 
-      const posts = { $ref: ['posts', 'post-abc'], $put: true };
+      const posts = put(ref(['posts', 'post-abc']));
       const expected = {
         users: { abc: { id: 'abc', posts } },
         posts: { 'post-abc': posts },
@@ -186,7 +186,7 @@ describe('ref', () => {
         },
       });
 
-      const posts = { $ref: ['posts'], title: null };
+      const posts = ref(['posts'], { title: null });
       const expected = {
         users: { abc: { id: 'abc', posts } },
         posts,

--- a/src/link/link.test.js
+++ b/src/link/link.test.js
@@ -3,6 +3,7 @@ import fill from '@graffy/fill';
 import { encodeGraph, encodeQuery } from '@graffy/common';
 import { mockBackend } from '@graffy/testing';
 import link from './index.js';
+import { ref, keyref } from '@graffy/testing';
 
 describe('link', () => {
   let store, backend;
@@ -39,21 +40,18 @@ describe('link', () => {
           {
             $key: { $all: true, authorId: 'ali', tag: 'z' },
             $chi: [
-              { $key: { id: 'p01' }, $ref: ['post', 'p01'] },
-              { $key: { id: 'p03' }, $ref: ['post', 'p03'] },
+              keyref({ id: 'p01' }, ['post', 'p01']),
+              keyref({ id: 'p03' }, ['post', 'p03']),
             ],
           },
           {
             $key: { $all: true, authorId: 'bob' },
             $chi: [
-              { $key: { id: 'p02' }, $ref: ['post', 'p02'] },
-              { $key: { id: 'p04' }, $ref: ['post', 'p04'] },
+              keyref({ id: 'p02' }, ['post', 'p02']),
+              keyref({ id: 'p04' }, ['post', 'p04']),
             ],
           },
-          {
-            $key: { top: true },
-            $ref: ['post', 'p01'],
-          },
+          keyref({ top: true }, ['post', 'p01']),
         ],
       }),
     );
@@ -71,7 +69,7 @@ describe('link', () => {
     });
     expect(res).toEqual({
       title: 'Post 1 A',
-      author: { $ref: ['user', 'ali'], name: 'Alicia' },
+      author: ref(['user', 'ali'], { name: 'Alicia' }),
     });
   });
 
@@ -85,22 +83,14 @@ describe('link', () => {
       ali: {
         name: 'Alicia',
         posts: [
-          {
-            $key: { $cursor: { id: 'p03' }, tag: 'z' },
-            $ref: ['post', 'p03'],
+          keyref({ $cursor: { id: 'p03' }, tag: 'z' }, ['post', 'p03'], {
             title: 'Post 3 a',
-          },
+          }),
         ],
       },
       bob: {
         name: 'Robert',
-        posts: [
-          {
-            $key: { id: 'p02' },
-            $ref: ['post', 'p02'],
-            title: 'Post 2 B',
-          },
-        ],
+        posts: [keyref({ id: 'p02' }, ['post', 'p02'], { title: 'Post 2 B' })],
       },
     };
 
@@ -129,11 +119,10 @@ describe('link', () => {
     ]);
 
     expect(res).toEqual([
-      {
-        $ref: ['post', 'p01'],
+      ref(['post', 'p01'], {
         title: 'Post 1 A',
-        author: { $ref: ['user', 'ali'], name: 'Alicia' },
-      },
+        author: ref(['user', 'ali'], { name: 'Alicia' }),
+      }),
     ]);
   });
 
@@ -163,15 +152,10 @@ describe('link', () => {
     const res = await resPromise;
 
     const exp = [
-      {
-        $key: { $cursor: { id: 'p02' }, authorId: 'bob' },
-        $ref: ['post', 'p02'],
+      keyref({ $cursor: { id: 'p02' }, authorId: 'bob' }, ['post', 'p02'], {
         title: 'Post 2 B',
-        author: {
-          $ref: ['user', 'bob'],
-          name: 'Robert',
-        },
-      },
+        author: ref(['user', 'bob'], { name: 'Robert' }),
+      }),
     ];
     exp.$page = { $all: true, authorId: 'bob', $until: { id: 'p02' } };
     exp.$next = { $first: 1, authorId: 'bob', $after: { id: 'p02' } };
@@ -189,8 +173,8 @@ describe('link', () => {
     const exp = {
       name: 'Carl',
       friends: [
-        { $key: 0, $ref: ['user', 'ali'], name: 'Alicia' },
-        { $key: 1, $ref: ['user', 'bob'], name: 'Robert' },
+        keyref(0, ['user', 'ali'], { name: 'Alicia' }),
+        keyref(1, ['user', 'bob'], { name: 'Robert' }),
       ],
     };
     exp.friends.$page = { $all: true };

--- a/src/pg/index.js
+++ b/src/pg/index.js
@@ -7,12 +7,13 @@ import Db from './Db.js';
  *    idCol?: string,
  *    verCol?: string,
  *    connection?: any,
- *    schema?: any
+ *    schema?: any,
+ *    verDefault?: string
  * }} options
  * @returns
  */
 export const pg =
-  ({ table, idCol, verCol, connection, schema }) =>
+  ({ table, idCol, verCol, connection, schema, verDefault }) =>
   (store) => {
     store.on('read', read);
     store.on('write', write);
@@ -25,6 +26,7 @@ export const pg =
       idCol: idCol || 'id',
       verCol: verCol || 'updatedAt',
       schema,
+      verDefault,
     };
 
     const defaultDb = new Db(connection);

--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -1,8 +1,6 @@
 import sql, { Sql, raw, join, empty } from 'sql-template-tag';
 import { encodePath, isEmpty } from '@graffy/common';
 
-export const nowTimestamp = sql`cast(extract(epoch from now()) as integer)`;
-
 /*
   Important: This function assumes that the object's keys are from
   trusted sources.
@@ -25,7 +23,8 @@ const getJsonBuildValue = (value) => {
 export const lookup = (prop) => {
   const [prefix, ...suffix] = encodePath(prop);
   return suffix.length
-    ? sql`"${raw(prefix)}" #> ${suffix}`
+    ? // @ts-ignore sql-template-tag typedef bug
+      sql`"${raw(prefix)}" #> ${suffix}`
     : sql`"${raw(prefix)}"`;
 };
 
@@ -103,7 +102,7 @@ export const getInsert = (row, options) => {
 
   Object.entries(row)
     .filter(([col]) => col !== options.verCol && col[0] !== '$')
-    .concat([[options.verCol, nowTimestamp]])
+    .concat([[options.verCol, sql`default`]])
     .forEach(([col, val]) => {
       cols.push(sql`"${raw(col)}"`);
       vals.push(castValue(val, options.schema.types[col], col, row.$put));
@@ -125,7 +124,7 @@ export const getUpdates = (row, options) => {
             row.$put,
           )}`,
       )
-      .concat(sql`"${raw(options.verCol)}" = ${nowTimestamp}`),
+      .concat(sql`"${raw(options.verCol)}" = default`),
     ', ',
   );
 };

--- a/src/pg/sql/getArgSql.js
+++ b/src/pg/sql/getArgSql.js
@@ -26,7 +26,7 @@ export default function getArgSql(
   }
 
   const meta = (key) =>
-    $group ? getAggMeta(key, $group) : getArgMeta(key, prefix, idCol);
+    $group ? getAggMeta(key, $group, options) : getArgMeta(key, options);
 
   const groupCols =
     Array.isArray($group) && $group.length && $group.map(lookup);

--- a/src/pg/sql/getMeta.js
+++ b/src/pg/sql/getMeta.js
@@ -1,23 +1,23 @@
 import sql, { join, raw } from 'sql-template-tag';
-import { getJsonBuildTrusted, nowTimestamp } from './clauses';
+import { getJsonBuildTrusted } from './clauses';
 
-export const getIdMeta = ({ idCol }) =>
+export const getIdMeta = ({ idCol, verDefault }) =>
   getJsonBuildTrusted({
     $key: sql`"${raw(idCol)}"`,
-    $ver: nowTimestamp,
+    $ver: raw(verDefault),
   });
 
-export const getArgMeta = (key, prefix, idCol) =>
+export const getArgMeta = (key, { prefix, idCol, verDefault }) =>
   getJsonBuildTrusted({
     $key: key,
     $ref: sql`jsonb_build_array(${join(
       prefix.map((k) => sql`${k}::text`),
     )}, "${raw(idCol)}")`,
-    $ver: nowTimestamp,
+    $ver: raw(verDefault),
   });
 
-export const getAggMeta = (key, $group) =>
+export const getAggMeta = (key, $group, { verDefault }) =>
   getJsonBuildTrusted({
     $key: join([key, getJsonBuildTrusted({ $group })].filter(Boolean), ' || '),
-    $ver: nowTimestamp,
+    $ver: raw(verDefault),
   });

--- a/src/pg/test/db/dbRead.test.js
+++ b/src/pg/test/db/dbRead.test.js
@@ -21,7 +21,12 @@ describe('postgres', () => {
     store = new Graffy();
     store.use(
       'user',
-      pg({ idCol: 'id', verCol: 'version', schema: { types: {} } }),
+      pg({
+        idCol: 'id',
+        verCol: 'version',
+        schema: { types: {} },
+        verDefault: 'current_timestamp',
+      }),
     );
   });
 
@@ -43,9 +48,8 @@ describe('postgres', () => {
     expect(mockQuery).toBeCalled();
     expectSql(
       mockQuery.mock.calls[0][0],
-      sql`SELECT to_jsonb ("user") || jsonb_build_object ( '$key' , "id" , '$ver' , cast ( extract ( epoch from now ( ) ) as integer ) )
-       FROM "user" WHERE "id" IN ( ${'foo'} )
-    `,
+      sql`SELECT to_jsonb ("user") || jsonb_build_object ( '$key' , "id" , '$ver' , current_timestamp )
+       FROM "user" WHERE "id" IN ( ${'foo'} )`,
     );
 
     expect(result).toEqual({

--- a/src/pg/test/setup.js
+++ b/src/pg/test/setup.js
@@ -80,7 +80,7 @@ export async function resetTables() {
       "name" text,
       "settings" jsonb,
       "email" text UNIQUE,
-      "version" int8 NOT NULL
+      "version" int8 NOT NULL DEFAULT extract(epoch from current_timestamp) * 1000
     );
   `);
 
@@ -95,7 +95,7 @@ export async function resetTables() {
       "authorId" text,
       "commenters" text[],
       "scores" cube,
-      "version" int8 NOT NULL
+      "version" int8 NOT NULL DEFAULT extract(epoch from current_timestamp) * 1000
     );
   `);
 }

--- a/src/pg/test/sql/clauses.test.js
+++ b/src/pg/test/sql/clauses.test.js
@@ -3,7 +3,6 @@ import expectSql from '../expectSql';
 import {
   getInsert,
   getUpdates,
-  nowTimestamp,
   getJsonBuildTrusted,
   getSelectCols,
 } from '../../sql/clauses';
@@ -15,9 +14,10 @@ describe('clauses', () => {
     const { cols, vals } = getInsert(data, {
       verCol: 'version',
       schema: { types: { a: 'int8', b: 'float', version: 'int8' } },
+      verDefault: 'current_timestamp',
     });
     expectSql(cols, sql`"a", "b", "version"`);
-    expectSql(vals, sql`${data.a} , ${data.b} , ${nowTimestamp}`);
+    expectSql(vals, sql`${data.a} , ${data.b} , default`);
   });
 
   test('updates', () => {
@@ -25,20 +25,21 @@ describe('clauses', () => {
       idCol: 'id',
       verCol: 'version',
       schema: { types: { a: 'int8', b: 'float', version: 'int8' } },
+      verDefault: 'current_timestamp',
     };
     const update = getUpdates(data, options);
     expectSql(
       update,
-      sql`"a" = ${data.a}, "b" = ${data.b}, "version" =  ${nowTimestamp}`,
+      sql`"a" = ${data.a}, "b" = ${data.b}, "version" =  default`,
     );
   });
 
   test('jsonBuildObject', () => {
-    const data = { a: 1, b: 2, version: nowTimestamp };
+    const data = { a: 1, b: 2, version: sql`default` };
     const query = getJsonBuildTrusted(data);
     expectSql(
       query,
-      sql`jsonb_build_object('a', ${'1'}::jsonb, 'b', ${'2'}::jsonb, 'version', ${nowTimestamp})`,
+      sql`jsonb_build_object('a', ${'1'}::jsonb, 'b', ${'2'}::jsonb, 'version', default)`,
     );
   });
 

--- a/src/pg/test/sql/select.test.js
+++ b/src/pg/test/sql/select.test.js
@@ -2,7 +2,6 @@ import { selectByArgs, selectByIds } from '../../sql/select.js';
 
 import sql, { raw } from 'sql-template-tag';
 import expectSql from '../expectSql.js';
-import { nowTimestamp } from '../../sql/clauses';
 
 describe('select_sql', () => {
   test('selectByArgs_first', () => {
@@ -13,6 +12,7 @@ describe('select_sql', () => {
       idCol: 'id',
       verCol: 'version',
       schema: { types: {} },
+      verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
       SELECT to_jsonb("${raw(options.table)}") || jsonb_build_object('$key',
@@ -20,7 +20,7 @@ describe('select_sql', () => {
           jsonb_build_object ('$cursor', jsonb_build_array("name","id"))),
         '$ref', jsonb_build_array(${
           options.table
-        }::text, "id"), '$ver', ${nowTimestamp}
+        }::text, "id"), '$ver', current_timestamp
       )
       FROM "user" ORDER BY "name" ASC, "id" ASC LIMIT ${10}
     `;
@@ -35,11 +35,12 @@ describe('select_sql', () => {
       prefix: ['user'],
       idCol: 'id',
       verCol: 'version',
+      verDefault: 'current_timestamp',
     };
 
     const expectedResult = sql`
       SELECT to_jsonb("${raw(options.table)}") || jsonb_build_object(
-        '$key', "${raw(options.idCol)}", '$ver', ${nowTimestamp}
+        '$key', "${raw(options.idCol)}", '$ver', current_timestamp
       )
       FROM "user" WHERE "id" IN (${ids[0]}, ${ids[1]})
     `;
@@ -53,6 +54,7 @@ describe('select_sql', () => {
       prefix: ['user'],
       idCol: 'id',
       verCol: 'version',
+      verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
       SELECT to_jsonb("${raw(options.table)}") || jsonb_build_object('$key',
@@ -60,7 +62,7 @@ describe('select_sql', () => {
           jsonb_build_object ('$cursor', jsonb_build_array("createTime","id"))),
         '$ref', jsonb_build_array(${
           options.table
-        }::text, "id"), '$ver', ${nowTimestamp}
+        }::text, "id"), '$ver', current_timestamp
       )
       FROM "user" ORDER BY "createTime" ASC, "id" ASC LIMIT ${10}
     `;
@@ -75,6 +77,7 @@ describe('select_sql', () => {
       prefix: ['user'],
       idCol: 'id',
       verCol: 'version',
+      verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
     SELECT to_jsonb("${raw(options.table)}") || jsonb_build_object('$key',
@@ -82,7 +85,7 @@ describe('select_sql', () => {
       jsonb_build_object ('$cursor', jsonb_build_array("createTime","id"))),
     '$ref', jsonb_build_array(${
       options.table
-    }::text, "id"), '$ver', ${nowTimestamp}
+    }::text, "id"), '$ver', current_timestamp
   )
   FROM "user"
   WHERE \"createTime\" < ${2} OR \"createTime\" = ${2} AND ( \"id\" < ${3} )

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -1,3 +1,19 @@
 export { default as mockBackend } from './mockBackend.js';
 export { default as format, inspect } from './format.js';
 export { default as pretty } from './pretty.js';
+
+export const put = (obj) => {
+  Object.defineProperty(obj, '$put', { value: true });
+  return obj;
+};
+
+export const ref = ($ref, obj = {}) => {
+  Object.defineProperty(obj, '$ref', { value: $ref });
+  return obj;
+};
+
+export const keyref = ($key, $ref, obj = {}) => {
+  obj.$key = $key;
+  ref($ref, obj);
+  return obj;
+};


### PR DESCRIPTION
Currently, the `version` column is always set to the database server timestamp, using the expression `extract (epoch from current_timestamp)`. This restricts applications to using second-precision timestamps as versions, which may not be appropriate for every use case.

This PR updates graffy-pg to instead use the default expression for the version column. As a consequence, it is now mandatory for the version column of a postgres table to have a default expression.

Other changes in this PR
- Make `$ref` and `$val` non-enumerable in graphs that are returned from store.read/write/watch or passed to store.onWrite providers. (The same was done for `$put` in #107).
- Miscellaneous type definition fixes on the road to getting Typescript green.