### PR TITLE
Fix link queries containing nested arrays

### DIFF
--- a/src/link/prepQueryLinks.js
+++ b/src/link/prepQueryLinks.js
@@ -176,7 +176,7 @@ function prepareDef(def, vars) {
       return '$$' + key.slice(2).split('.').flatMap(getValue).join('.');
     }
     if (Array.isArray(key)) {
-      return key.flatMap(replacePlaceholders);
+      return key.map(replacePlaceholders);
     }
     if (typeof key === 'object' && key) {
       const result = {};
@@ -185,6 +185,6 @@ function prepareDef(def, vars) {
     }
     return getValue(key);
   }
-  const ref = def.flatMap(replacePlaceholders);
+  const ref = def.map(replacePlaceholders);
   return ref;
 }

--- a/src/link/prepQueryLinks.test.js
+++ b/src/link/prepQueryLinks.test.js
@@ -89,3 +89,39 @@ test('parallelLookups', () => {
     },
   ]);
 });
+
+test('cube_args', () => {
+  /*
+  $id.prospect’: [
+                ‘prospect’,
+                { tenantId: ‘$$$id.tenantId’, $all: true },
+            ],
+  */
+  const defs = [
+    {
+      path: ['foo', '$id', 'prospect'],
+      def: ['prospect', { tenantId: '$$$id.tenantId', $all: true }],
+    },
+  ];
+
+  const quantities = {
+    $ctd: [
+      [-Infinity, -Infinity],
+      [Infinity, Infinity],
+    ],
+  };
+
+  const query = encodeQuery({
+    foo: {
+      abc: {
+        prospect: {
+          $key: { quantities },
+          name: true,
+        },
+      },
+    },
+  });
+
+  const usedDefs = prepQueryLinks(query, defs);
+  expect(usedDefs[0].def[1].quantities).toEqual(quantities);
+});


### PR DESCRIPTION
Fixes the issue with cube $ctd filters, that contain nested arrays, being flattened.