### PR TITLE
Link key placeholder

### DIFF
--- a/src/link/linkGraph.js
+++ b/src/link/linkGraph.js
@@ -98,13 +98,16 @@ export default function linkGraph(rootGraph, defs) {
       return lookupValues(rootGraph, key.slice(2).split('.'));
     }
     if (Array.isArray(key)) {
+      if (!key.length) return [{ value: [], vars: {} }];
       return unbraid(key.map(getChoices));
     }
     if (typeof key === 'object' && key) {
       const [range = {}, filter = {}] = splitArgs(key);
-      const entries = unbraid(Object.entries(filter).flat().map(getChoices));
+      const entries = Object.entries(filter).flat();
+      if (!entries.length) return [{ value: {}, vars: {} }];
+      const strands = unbraid(entries.map(getChoices));
 
-      return entries.map(({ value, vars }) => ({
+      return strands.map(({ value, vars }) => ({
         value: {
           ...range,
           ...Object.fromEntries(

--- a/src/link/linkGraph.test.js
+++ b/src/link/linkGraph.test.js
@@ -132,3 +132,41 @@ test('placeholder_in_key', () => {
     ),
   );
 });
+
+test('gate_pattern', () => {
+  const defs = [
+    {
+      path: ['abcdef', 'prospect', '\x000kKaQqw-0kJZNrGn--R4Na4m--R'],
+      def: [
+        'prospect',
+        {
+          tenantId: '$$abcdef.tenantId',
+          foo: { $cts: { bar: {} } },
+          $all: true,
+        },
+      ],
+    },
+  ];
+  const graph = encodeGraph({ abcdef: { tenantId: 'xyz' } }, 0);
+  const res = linkGraph(graph, defs);
+
+  expect(res).toEqual(
+    encodeGraph(
+      {
+        abcdef: {
+          tenantId: 'xyz',
+          prospect: [
+            {
+              $key: { $all: true, foo: { $cts: { bar: {} } } },
+              $ref: [
+                'prospect',
+                { foo: { $cts: { bar: {} } }, tenantId: 'xyz' },
+              ],
+            },
+          ],
+        },
+      },
+      0,
+    ),
+  );
+});

--- a/src/link/linkGraph.test.js
+++ b/src/link/linkGraph.test.js
@@ -37,40 +37,34 @@ test('simple', () => {
   );
 });
 
-test.skip('complex', () => {
-  const graph = encodeGraph(
-    {
-      foo: [
-        { $key: 'two', x: 30 },
-        { $key: 'three', x: 33 },
-      ],
-    },
-    0,
-  );
-
+test('placeholder_in_key', () => {
   const defs = [
     {
-      path: ['bar', '$n', 'x'],
-      def: ['baz', '$$foo.$n.x', { number: '$n', $all: true }],
+      path: ['person', 'abcdef', 'prospect', ''],
+      def: [
+        'prospect',
+        { $all: true, persons: { '$$person.abcdef.id': true } },
+      ],
     },
   ];
-  expect(linkGraph(graph, defs)).toEqual(
+
+  const graph = encodeGraph({ person: { abcdef: { id: 'abcdef' } } }, 0);
+  const res = linkGraph(graph, defs);
+
+  expect(res).toEqual(
     encodeGraph(
       {
-        foo: [
-          { $key: 'two', x: 30 },
-          { $key: 'three', x: 33 },
-        ],
-        bar: [
-          {
-            $key: 'two',
-            x: { $ref: ['baz', 30, { number: 'two', $all: true }] },
+        person: {
+          abcdef: {
+            id: 'abcdef',
+            prospect: [
+              {
+                $key: { $all: true },
+                $ref: ['prospect', { persons: { abcdef: true } }],
+              },
+            ],
           },
-          {
-            $key: 'three',
-            x: { $ref: ['baz', 33, { number: 'three', $all: true }] },
-          },
-        ],
+        },
       },
       0,
     ),

--- a/src/link/linkGraph.test.js
+++ b/src/link/linkGraph.test.js
@@ -37,6 +37,68 @@ test('simple', () => {
   );
 });
 
+test('compat', () => {
+  const graph = encodeGraph(
+    {
+      post: {
+        p1: {
+          authors: [{ id: 'bob' }],
+          category: 'cooking',
+        },
+        bob: {
+          authors: [{ id: 'ali' }, { id: 'carl' }],
+          category: 'fitness',
+        },
+      },
+    },
+    0,
+  );
+
+  const defs = [
+    {
+      path: ['post', '$i', 'authors', '$j', 'tagline'],
+      def: [
+        'user',
+        '$$post.$i.authors.$j.id',
+        'taglines',
+        '$$post.$i.category',
+      ],
+    },
+  ];
+
+  expect(linkGraph(graph, defs)).toEqual(
+    encodeGraph(
+      {
+        post: {
+          p1: {
+            authors: [
+              {
+                id: 'bob',
+                tagline: { $ref: ['user', 'bob', 'taglines', 'cooking'] },
+              },
+            ],
+            category: 'cooking',
+          },
+          bob: {
+            authors: [
+              {
+                id: 'ali',
+                tagline: { $ref: ['user', 'ali', 'taglines', 'fitness'] },
+              },
+              {
+                id: 'carl',
+                tagline: { $ref: ['user', 'carl', 'taglines', 'fitness'] },
+              },
+            ],
+            category: 'fitness',
+          },
+        },
+      },
+      0,
+    ),
+  );
+});
+
 test('placeholder_in_key', () => {
   const defs = [
     {

--- a/src/link/prepQueryLinks.test.js
+++ b/src/link/prepQueryLinks.test.js
@@ -91,12 +91,6 @@ test('parallelLookups', () => {
 });
 
 test('cube_args', () => {
-  /*
-  $id.prospect’: [
-                ‘prospect’,
-                { tenantId: ‘$$$id.tenantId’, $all: true },
-            ],
-  */
   const defs = [
     {
       path: ['foo', '$id', 'prospect'],
@@ -115,7 +109,7 @@ test('cube_args', () => {
     foo: {
       abc: {
         prospect: {
-          $key: { quantities },
+          $key: { quantities, $first: 10 },
           name: true,
         },
       },
@@ -124,4 +118,40 @@ test('cube_args', () => {
 
   const usedDefs = prepQueryLinks(query, defs);
   expect(usedDefs[0].def[1].quantities).toEqual(quantities);
+});
+
+test('placeholder_in_key', () => {
+  const defs = [
+    {
+      path: ['person', '$i', 'prospect'],
+      def: ['prospect', { $all: true, persons: { '$$person.$i.id': true } }],
+    },
+  ];
+
+  const query = encodeQuery({
+    person: {
+      abcdef: {
+        prospect: {
+          $key: { $first: 10 },
+          title: true,
+        },
+      },
+    },
+  });
+
+  const usedDefs = prepQueryLinks(query, defs);
+  expect(usedDefs).toEqual([
+    {
+      path: ['person', 'abcdef', 'prospect', ''],
+      def: [
+        'prospect',
+        { $all: true, persons: { '$$person.abcdef.id': true } },
+      ],
+    },
+  ]);
+  expect(query).toEqual(
+    encodeQuery({
+      person: { abcdef: { id: true } },
+    }),
+  );
 });

--- a/src/link/prepQueryLinks.test.js
+++ b/src/link/prepQueryLinks.test.js
@@ -155,3 +155,36 @@ test('placeholder_in_key', () => {
     }),
   );
 });
+
+test('gate_pattern', () => {
+  const defs = [
+    {
+      path: ['$id', 'prospect'],
+      def: ['prospect', { $all: true, tenantId: '$$$id.tenantId' }],
+    },
+  ];
+
+  const query = encodeQuery({
+    abcdef: {
+      prospect: {
+        $key: { $first: 10, persons: { $cts: { bar: {} } } },
+        title: true,
+      },
+    },
+  });
+
+  const usedDefs = prepQueryLinks(query, defs);
+  expect(usedDefs).toEqual([
+    {
+      path: ['abcdef', 'prospect', '\x000kKkOM8nQqtn--R485CoRk-60L8WRV-6'],
+      def: [
+        'prospect',
+        {
+          tenantId: '$$abcdef.tenantId',
+          persons: { $cts: { bar: {} } },
+          $all: true,
+        },
+      ],
+    },
+  ]);
+});


### PR DESCRIPTION
Allow placeholders as object keys inside link definitions, as is required to do `$cts`. This also removes the "required placeholders fulfillment check" mechanism, which was falsely flagging keys like `$all` and `$cts` as missing placeholders; the check doesn't seem to be required.