### PR TITLE
Stop stringifying strings for JSON comparison

### DIFF
--- a/src/pg/filter/getSql.js
+++ b/src/pg/filter/getSql.js
@@ -43,6 +43,9 @@ function getBinarySql(lhs, type, op, value, textLhs) {
   }
 
   if (type === 'jsonb') {
+    if (typeof value === 'string') {
+      return sql`${textLhs} ${sqlOp} ${value}`;
+    }
     return sql`${lhs} ${sqlOp} ${JSON.stringify(value)}::jsonb`;
   }
 

--- a/src/pg/test/filter/getSql.test.js
+++ b/src/pg/test/filter/getSql.test.js
@@ -81,3 +81,15 @@ test('regex text', () => {
     sql`"name" ~ ${'abc'}`,
   );
 });
+
+test('jsonb eq number', () => {
+  expect(getSql({ 'data.Score': 3 }, opt({ data: 'jsonb' }))).toEqual(
+    sql`"data" #> ${['Score']} = ${'3'}::jsonb`,
+  );
+});
+
+test('jsonb eq text', () => {
+  expect(getSql({ 'data.Name': 'Bob' }, opt({ data: 'jsonb' }))).toEqual(
+    sql`"data" #>> ${['Name']} = ${'Bob'}`,
+  );
+});


### PR DESCRIPTION
This allows the client to provide BTree indexes.