### PR TITLE
pg, perf: Do less JSON manipulation in the DB

### DIFF
--- a/src/pg/sql/getMeta.js
+++ b/src/pg/sql/getMeta.js
@@ -1,23 +1,17 @@
 import sql, { join, raw } from 'sql-template-tag';
-import { getJsonBuildTrusted } from './clauses';
 
 export const getIdMeta = ({ idCol, verDefault }) =>
-  getJsonBuildTrusted({
-    $key: sql`"${raw(idCol)}"`,
-    $ver: raw(verDefault),
-  });
+  sql`"${raw(idCol)}" AS "$key", ${raw(verDefault)} AS "$ver"`;
 
 export const getArgMeta = (key, { prefix, idCol, verDefault }) =>
-  getJsonBuildTrusted({
-    $key: key,
-    $ref: sql`jsonb_build_array(${join(
-      prefix.map((k) => sql`${k}::text`),
-    )}, "${raw(idCol)}")`,
-    $ver: raw(verDefault),
-  });
+  sql`
+    ${key} AS "$key",
+    ${raw(verDefault)} AS "$ver",
+    array[
+      ${join(prefix.map((k) => sql`${k}::text`))},
+      "${raw(idCol)}"
+    ]::text[] AS "$ref"
+  `;
 
 export const getAggMeta = (key, { verDefault }) =>
-  getJsonBuildTrusted({
-    $key: key,
-    $ver: raw(verDefault),
-  });
+  sql`${key} AS "$key", ${raw(verDefault)} AS "$ver"`;

--- a/src/pg/sql/select.js
+++ b/src/pg/sql/select.js
@@ -11,7 +11,7 @@ export function selectByArgs(args, projection, options) {
   const clampedLimit = Math.min(MAX_LIMIT, limit || MAX_LIMIT);
   return sql`
     SELECT
-    ${getSelectCols(table, projection)} || ${meta}
+    ${getSelectCols(table, projection)}, ${meta}
     FROM "${raw(table)}"
     ${where.length ? sql`WHERE ${join(where, ` AND `)}` : empty}
     ${group ? sql`GROUP BY ${group}` : empty}
@@ -24,7 +24,7 @@ export function selectByIds(ids, projection, options) {
   const { table, idCol } = options;
   return sql`
     SELECT
-    ${getSelectCols(table, projection)} || ${getIdMeta(options)}
+    ${getSelectCols(table, projection)}, ${getIdMeta(options)}
     FROM "${raw(table)}"
     WHERE "${raw(idCol)}" IN (${join(ids)})
   `;

--- a/src/pg/sql/upsert.js
+++ b/src/pg/sql/upsert.js
@@ -2,12 +2,7 @@ import sql, { raw, join } from 'sql-template-tag';
 import { isPlainObject } from '@graffy/common';
 import getArgSql from './getArgSql.js';
 import { getIdMeta } from './getMeta.js';
-import {
-  getInsert,
-  getJsonBuildTrusted,
-  getSelectCols,
-  getUpdates,
-} from './clauses.js';
+import { getInsert, getSelectCols, getUpdates } from './clauses.js';
 
 function getSingleSql(arg, options) {
   const { table, idCol } = options;
@@ -42,7 +37,7 @@ export function patch(object, arg, options) {
   return sql`
     UPDATE "${raw(table)}" SET ${getUpdates(row, options)}
     WHERE ${where}
-    RETURNING (${getSelectCols(table)} || ${meta})`;
+    RETURNING ${getSelectCols(table)}, ${meta}`;
 }
 
 export function put(object, arg, options) {
@@ -63,7 +58,7 @@ export function put(object, arg, options) {
   return sql`
     INSERT INTO "${raw(table)}" (${cols}) VALUES (${vals})
     ON CONFLICT (${conflictTarget}) DO UPDATE SET (${cols}) = (${vals})
-    RETURNING (${getSelectCols(table)} || ${meta})`;
+    RETURNING ${getSelectCols(table)}, ${meta}`;
 }
 
 export function del(arg, options) {
@@ -73,5 +68,5 @@ export function del(arg, options) {
   return sql`
     DELETE FROM "${raw(table)}"
     WHERE ${where}
-    RETURNING (${getJsonBuildTrusted({ $key: arg })})`;
+    RETURNING ${arg} "$key"`;
 }

--- a/src/pg/test/db/dbRead.test.js
+++ b/src/pg/test/db/dbRead.test.js
@@ -48,8 +48,8 @@ describe('postgres', () => {
     expect(mockQuery).toBeCalled();
     expectSql(
       mockQuery.mock.calls[0][0],
-      sql`SELECT to_jsonb ("user") || jsonb_build_object ( '$key' , "id" , '$ver' , current_timestamp )
-       FROM "user" WHERE "id" IN ( ${'foo'} )`,
+      sql`SELECT *, "id" AS "$key", current_timestamp AS "$ver"
+        FROM "user" WHERE "id" IN ( ${'foo'} )`,
     );
 
     expect(result).toEqual({

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -880,7 +880,7 @@ describe('pg_e2e', () => {
       value: [{ $since: 0, $until: Infinity }],
     });
 
-    expect(res1[pid1].commenters).toEqual(exp1[pid1].commenters);
+    expect(res1).toEqual(exp1);
 
     // Case 2: Cube query
 

--- a/src/pg/test/setup.js
+++ b/src/pg/test/setup.js
@@ -50,7 +50,7 @@ export async function setupPgServer() {
       throw e;
     }
 
-  while (!(await isPgReady(connOptions.port))) await sleep(200);
+  while (!(await isPgReady())) await sleep(200);
   // console.log('Postgres is up in', Date.now() - start, 'ms');
 
   pool = new Pool(connOptions);

--- a/src/pg/test/sql/clauses.test.js
+++ b/src/pg/test/sql/clauses.test.js
@@ -1,4 +1,4 @@
-import sql, { raw } from 'sql-template-tag';
+import sql from 'sql-template-tag';
 import expectSql from '../expectSql';
 import {
   getInsert,
@@ -46,6 +46,6 @@ describe('clauses', () => {
   test('selectCols', () => {
     const table = 'test';
     const query = getSelectCols(table);
-    expectSql(query, sql`to_jsonb("${raw(table)}")`);
+    expectSql(query, sql`*`);
   });
 });

--- a/src/pg/test/sql/select.test.js
+++ b/src/pg/test/sql/select.test.js
@@ -1,6 +1,6 @@
 import { selectByArgs, selectByIds } from '../../sql/select.js';
 
-import sql, { raw } from 'sql-template-tag';
+import sql from 'sql-template-tag';
 import expectSql from '../expectSql.js';
 
 describe('select_sql', () => {
@@ -15,13 +15,12 @@ describe('select_sql', () => {
       verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
-      SELECT to_jsonb("${raw(options.table)}") || jsonb_build_object('$key',
-        ( ${JSON.stringify({ $order: ['name', 'id'] })}::jsonb ||
-          jsonb_build_object ('$cursor', jsonb_build_array("name","id"))),
-        '$ref', jsonb_build_array(${
-          options.table
-        }::text, "id"), '$ver', current_timestamp
-      )
+      SELECT *, (
+          ${JSON.stringify({ $order: ['name', 'id'] })}::jsonb ||
+          jsonb_build_object ('$cursor', jsonb_build_array("name","id"))
+        ) AS "$key",
+        current_timestamp AS "$ver",
+        array[ ${options.table}::text, "id" ]::text[] AS "$ref"
       FROM "user" ORDER BY "name" ASC, "id" ASC LIMIT ${10}
     `;
 
@@ -39,9 +38,7 @@ describe('select_sql', () => {
     };
 
     const expectedResult = sql`
-      SELECT to_jsonb("${raw(options.table)}") || jsonb_build_object(
-        '$key', "${raw(options.idCol)}", '$ver', current_timestamp
-      )
+      SELECT *, "id" AS "$key", current_timestamp AS "$ver"
       FROM "user" WHERE "id" IN (${ids[0]}, ${ids[1]})
     `;
     expectSql(selectByIds(ids, null, options), expectedResult);
@@ -57,13 +54,12 @@ describe('select_sql', () => {
       verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
-      SELECT to_jsonb("${raw(options.table)}") || jsonb_build_object('$key',
-        ( ${JSON.stringify({ $order: ['createTime', 'id'] })}::jsonb ||
-          jsonb_build_object ('$cursor', jsonb_build_array("createTime","id"))),
-        '$ref', jsonb_build_array(${
-          options.table
-        }::text, "id"), '$ver', current_timestamp
-      )
+      SELECT *, (
+          ${JSON.stringify({ $order: ['createTime', 'id'] })}::jsonb ||
+          jsonb_build_object ('$cursor', jsonb_build_array("createTime","id"))
+        ) AS "$key",
+        current_timestamp AS "$ver",
+        array[ ${options.table}::text, "id" ]::text[] AS "$ref"
       FROM "user" ORDER BY "createTime" ASC, "id" ASC LIMIT ${10}
     `;
 
@@ -80,17 +76,16 @@ describe('select_sql', () => {
       verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
-    SELECT to_jsonb("${raw(options.table)}") || jsonb_build_object('$key',
-    ( ${JSON.stringify({ $order: ['createTime', 'id'] })}::jsonb ||
-      jsonb_build_object ('$cursor', jsonb_build_array("createTime","id"))),
-    '$ref', jsonb_build_array(${
-      options.table
-    }::text, "id"), '$ver', current_timestamp
-  )
-  FROM "user"
-  WHERE \"createTime\" < ${2} OR \"createTime\" = ${2} AND ( \"id\" < ${3} )
-  ORDER BY "createTime" ASC, "id" ASC LIMIT ${4096}
-`;
+      SELECT *, (
+          ${JSON.stringify({ $order: ['createTime', 'id'] })}::jsonb ||
+          jsonb_build_object ('$cursor', jsonb_build_array("createTime","id"))
+        ) AS "$key",
+        current_timestamp AS "$ver",
+        array[ ${options.table}::text, "id" ]::text[] AS "$ref"
+      FROM "user"
+      WHERE \"createTime\" < ${2} OR \"createTime\" = ${2} AND ( \"id\" < ${3} )
+      ORDER BY "createTime" ASC, "id" ASC LIMIT ${4096}
+    `;
 
     expectSql(selectByArgs(arg, null, options), expectedResult);
   });
@@ -105,12 +100,12 @@ describe('select_sql', () => {
       verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
-      SELECT to_jsonb("${raw(options.table)}") || jsonb_build_object('$key',
-        (${`{}`}::jsonb || jsonb_build_object ('$cursor', jsonb_build_array("id"))),
-        '$ref', jsonb_build_array(${
-          options.table
-        }::text, "id"), '$ver', current_timestamp
-      )
+      SELECT *, (
+          ${`{}`}::jsonb ||
+          jsonb_build_object ('$cursor', jsonb_build_array("id"))
+        ) AS "$key",
+        current_timestamp AS "$ver",
+        array[ ${options.table}::text, "id" ]::text[] AS "$ref"
       FROM "user" ORDER BY "id" ASC LIMIT ${10}
     `;
 

--- a/src/pg/test/sql/upsert.test.js
+++ b/src/pg/test/sql/upsert.test.js
@@ -45,8 +45,7 @@ describe('byId', () => {
         = (${'post22'}, ${'post'}, ${'hello'},${'world'},
         ${JSON.stringify({ foo: 3 })},
         ${JSON.stringify([1, 2])}, default)
-      RETURNING (to_jsonb("post") ||
-        jsonb_build_object('$key', "id", '$ver', current_timestamp))
+      RETURNING *, "id" AS "$key", current_timestamp AS "$ver"
     `,
     );
   });
@@ -74,8 +73,7 @@ describe('byId', () => {
         "tags" = jsonb_strip_nulls(${JSON.stringify([1, 2, 3])}::jsonb),
         "version" =  default
       WHERE "id" = ${'post22'}
-      RETURNING (to_jsonb("post") ||
-        jsonb_build_object('$key', "id", '$ver', current_timestamp))
+      RETURNING *, "id" AS "$key", current_timestamp AS "$ver"
     `,
     );
   });
@@ -99,11 +97,10 @@ describe('byArg', () => {
       VALUES (${'post22'}, ${'post'}, ${'hello'},${'world'}, default)
       ON CONFLICT ("email") DO UPDATE SET ("id", "type", "name", "email", "version")
         = (${'post22'}, ${'post'}, ${'hello'},${'world'},  default)
-      RETURNING (to_jsonb("post") ||
-        jsonb_build_object(
-          '$key', ${'{"email":"world"}'}::jsonb,
-          '$ref', jsonb_build_array(${'post'}::text, "id"),
-          '$ver', current_timestamp))`,
+      RETURNING *,
+        ${'{"email":"world"}'}::jsonb AS "$key",
+        current_timestamp AS "$ver",
+        array[ ${'post'}::text, "id" ]::text[] AS "$ref"`,
     );
   });
 
@@ -125,11 +122,10 @@ describe('byArg', () => {
         "email" = ${'world'},
         "version" =  default
       WHERE "id" = (SELECT "id" FROM "post" WHERE "email" = ${'world'} LIMIT 1)
-      RETURNING (to_jsonb("post") ||
-        jsonb_build_object(
-          '$key', ${'{"email":"world"}'}::jsonb,
-          '$ref', jsonb_build_array(${'post'}::text, "id"),
-          '$ver', current_timestamp))`,
+      RETURNING *,
+        ${'{"email":"world"}'}::jsonb AS "$key",
+        current_timestamp AS "$ver",
+        array[ ${'post'}::text, "id" ]::text[] AS "$ref"`,
     );
   });
 });


### PR DESCRIPTION
Previously, pg generated SQL that would return JSON objects in the response. This moved the cost of JSON encoding out of the application and into the database.

This was the wrong trade-off: databases are harder to scale, and using JSONB objects instead of native PostgreSQL records resulted in an 8-10X reduction in Postgres' CPU consumption for simple queries (where the difference is expected to be most).

This change removes most of the json manipulation in read queries. However note that:
- the Graffy $key attribute is still calculated within the database: this means that we continue to use `jsonb_build_object` and the JSON concatenation operator (`||`) in range queries. However $key is typically small, and the cost of encoding it is likely much smaller than the cost of encoding whole result objects.
- The patch operation (update) still uses JSON manipulation in the `SET` clause.