### PR TITLE
Fix PG updates that delete all children of an object

### DIFF
--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -174,7 +174,7 @@ function stripAttributes(object) {
   }
 
   return Object.entries(object).reduce((out, [key, val]) => {
-    if (key === '$put') return out;
+    if (key === '$put' || val === null) return out;
     out[key] = stripAttributes(val);
     return out;
   }, {});

--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -100,7 +100,7 @@ function castValue(value, type, name, isPut) {
   if (type === 'jsonb') {
     return isPut
       ? JSON.stringify(stripAttributes(value))
-      : sql`jsonb_strip_nulls(${getJsonUpdate(value, name, [])})`;
+      : getJsonUpdate(value, name, []);
   }
 
   if (type === 'cube') return cubeLiteralSql(value);
@@ -154,7 +154,7 @@ function getJsonUpdate(object, col, path) {
   const curr = sql`"${raw(col)}"${path.length ? sql`#>${path}` : empty}`;
   if (isEmpty(object)) return curr;
 
-  return sql`(case jsonb_typeof(${curr})
+  return sql`nullif(jsonb_strip_nulls((case jsonb_typeof(${curr})
     when 'object' then ${curr}
     else '{}'::jsonb
   end) || jsonb_build_object(${join(
@@ -164,7 +164,7 @@ function getJsonUpdate(object, col, path) {
         sql`${key}::text, ${getJsonUpdate(value, col, path.concat(key))}`,
     ),
     ', ',
-  )})`;
+  )})), '{}'::jsonb)`;
 }
 
 function stripAttributes(object) {

--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -175,7 +175,8 @@ function stripAttributes(object) {
 
   return Object.entries(object).reduce((out, [key, val]) => {
     if (key === '$put' || val === null) return out;
+    if (out === null) out = {};
     out[key] = stripAttributes(val);
     return out;
-  }, {});
+  }, null);
 }

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1042,4 +1042,26 @@ describe('pg_e2e', () => {
     test('num_lt', async () => doTest({ 'settings.num': { $lt: 12 } }, ['A']));
     test('num_gt', async () => doTest({ 'settings.num': { $gt: 13 } }, ['B']));
   });
+
+  test('update_single_child_null', async () => {
+    let id = uuid();
+    await store.write('users', [{
+      $key: id,
+      $put: true,
+      name: 'A',
+      settings: { foo: { bar: 33 } },
+    }]);
+
+    await store.write(['users', id], {
+      settings: { foo: { bar: null } }
+    });
+
+    const pgClient = await getPool().connect();
+    const res = (await pgClient.query(`SELECT "settings" from "users" where id = '${id}'`)).rows[0];
+    pgClient.release();
+
+    expect(res).toEqual({ settings: null });
+
+    
+  })
 });

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1045,21 +1045,25 @@ describe('pg_e2e', () => {
 
   test('update_single_child_null', async () => {
     let id = uuid();
-    await store.write('users', [{
-      $key: id,
-      $put: true,
-      name: 'A',
-      settings: { foo: { bar: 33 } },
-    }]);
+    await store.write('users', [
+      {
+        $key: id,
+        $put: true,
+        name: 'A',
+        settings: { foo: { bar: 33 } },
+      },
+    ]);
 
     await store.write(['users', id], {
-      settings: { foo: { bar: null }, baz: { $put: true, bar: null } }
+      settings: { foo: { bar: null }, baz: { $put: true, bar: null } },
     });
 
     const pgClient = await getPool().connect();
-    const res = (await pgClient.query(`SELECT "settings" from "users" where id = '${id}'`)).rows[0];
+    const res = (
+      await pgClient.query(`SELECT "settings" from "users" where id = '${id}'`)
+    ).rows[0];
     pgClient.release();
 
     expect(res).toEqual({ settings: null });
-  })
+  });
 });

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1053,7 +1053,7 @@ describe('pg_e2e', () => {
     }]);
 
     await store.write(['users', id], {
-      settings: { foo: { bar: null } }
+      settings: { foo: { bar: null }, baz: { $put: true, bar: null } }
     });
 
     const pgClient = await getPool().connect();
@@ -1061,7 +1061,5 @@ describe('pg_e2e', () => {
     pgClient.release();
 
     expect(res).toEqual({ settings: null });
-
-    
   })
 });

--- a/src/pg/test/sql/upsert.test.js
+++ b/src/pg/test/sql/upsert.test.js
@@ -68,9 +68,9 @@ describe('byId', () => {
         "type" = ${'post'},
         "name" = ${'hello'},
         "email" = ${'world'},
-        "config" = jsonb_strip_nulls((case jsonb_typeof("config") when 'object' then "config" else '{}'::jsonb end) ||
-          jsonb_build_object ( ${'foo'}::text , ${'3'}::jsonb)),
-        "tags" = jsonb_strip_nulls(${JSON.stringify([1, 2, 3])}::jsonb),
+        "config" = nullif(jsonb_strip_nulls((case jsonb_typeof("config") when 'object' then "config" else '{}'::jsonb end) ||
+          jsonb_build_object ( ${'foo'}::text , ${'3'}::jsonb)), '{}'::jsonb),
+        "tags" = ${JSON.stringify([1, 2, 3])}::jsonb,
         "version" =  default
       WHERE "id" = ${'post22'}
       RETURNING *, "id" AS "$key", current_timestamp AS "$ver"


### PR DESCRIPTION
Empty objects aren't representable in Graffy, and the "merge" operation removes them automatically. However, the SQL implementation of the merge expression lacked this capability.

This PR adds it. This has the cost of calls to `jsonb_strip_nulls` and `nullif` at every branch that's updated, while previously there was only one call to `jsonb_strip_nulls` at the root.

In the new logic, the call to `jsonb_strip_nulls` is skipped when writing an object with `$put: true`; this needs additional sanitization code, which is also added in this PR.