### PR TITLE
PG: Support for joins/subqueries

### DIFF
--- a/src/core/Graffy.js
+++ b/src/core/Graffy.js
@@ -13,7 +13,7 @@ import {
 } from '@graffy/common';
 import { makeStream, mapStream } from '@graffy/stream';
 import { validateCall, validateOn } from './validate.js';
-import { shiftFn, shiftGen } from './shift.js';
+import { wrapProvider, shiftGen } from './shift.js';
 import Core from './Core.js';
 
 export default class Graffy {
@@ -31,36 +31,7 @@ export default class Graffy {
   onRead(...args) {
     const [pathArg, handle] = validateOn(...args);
     const path = this.path.concat(pathArg);
-    this.core.on(
-      'read',
-      path,
-      shiftFn(async function porcelainRead(query, options, next) {
-        // console.log('onRead', path, query);
-        const porcelainQuery = decodeQuery(query);
-        // console.log('porcelainQuery', path, porcelainQuery);
-        let nextCalled = false;
-        const encoded = encodeGraph(
-          await handle(porcelainQuery, options, async (nextQuery, nextOpts) => {
-            nextCalled = true;
-            const nextResult = await next(encodeQuery(nextQuery), nextOpts);
-            return decodeGraph(nextResult);
-          }),
-        );
-
-        let final;
-        if (!nextCalled) {
-          const encodedPath = encodePath(path);
-          final = unwrap(
-            finalize(wrap(encoded, encodedPath), wrap(query, encodedPath)),
-            encodedPath,
-          );
-        } else {
-          final = encoded;
-        }
-        // console.log({ encoded });
-        return final;
-      }, path),
-    );
+    this.core.on('read', path, wrapProvider(handle, path, true));
   }
 
   onWatch(...args) {
@@ -95,22 +66,7 @@ export default class Graffy {
   onWrite(...args) {
     const [pathArg, handle] = validateOn(...args);
     const path = this.path.concat(pathArg);
-    this.core.on(
-      'write',
-      path,
-      shiftFn(async function porcelainWrite(change, options, next) {
-        return encodeGraph(
-          await handle(
-            decodeGraph(change),
-            options,
-            async (nextChange, nextOpts) => {
-              const nextResult = await next(encodeGraph(nextChange), nextOpts);
-              return decodeGraph(nextResult);
-            },
-          ),
-        );
-      }, path),
-    );
+    this.core.on('write', path, wrapProvider(handle, path, false));
   }
 
   use(...args) {

--- a/src/core/test/read.test.js
+++ b/src/core/test/read.test.js
@@ -232,7 +232,7 @@ describe('alias', () => {
   });
 });
 
-describe.skip('middleware_coding', () => {
+describe('middleware_coding', () => {
   test('no_path', async () => {
     const composedResult = [
       keyref({ foo: 'bar', $cursor: [3847, 'p1'] }, ['participant', 'p1'], {

--- a/src/pg/Readme.md
+++ b/src/pg/Readme.md
@@ -20,6 +20,9 @@ store.use(path, pg(options));
 - `table`, the name of the table. If not provided, the last segment of the `path` is used. This table must exist.
 - `idCol`: the name of the column to use as ID. Defaults to `id`. This column must exist and be the primary key or have a unique constraint.
 - `verCol`: the name of the column to store the Graffy version number. This column must exist, and must have a `DEFAULT` SQL expression defined - this expression is evaluated to calculate the version number. Graffy versions must monotonically increase, so this expression is typically based on `CURRENT_TIMESTAMP`.
+- `joins`: other tables that have foreign keys referencing the ID column in this table, where we want to filter this table using columns of that other table via a "join". The value is a map of join names to join options.
+  - join names are the names used to refer to joined tables in filter expressions. Typically, these are the names of those tables.
+  - join options are objects with optional properties `table`, `idCol`, `refCol` and `verCol`. `refCol` is the name of the column in the join table that references this one. 
 - `connection`: a [pg](https://github.com/brianc/node-postgres) Client or Pool object (recommended), or the arguments for constructing a new Pool object. Optional.
 
 ### Database connection
@@ -88,6 +91,9 @@ For this to work, `foo` must be a TSVector column.
 Tags must contain both *foo* and *bar*. Note that the array of conditions here does not have `OR` semantics.
 2. `{ tags: { $ctd: ['foo', 'bar', 'baz'] } }` becomes `tags <@ '{"foo","bar","baz"}'`.
 Every tag must be one of *foo*, *bar* or *baz*.
+
+#### Joins
+1. `joinName: { ...expression }`,
 
 #### Notes
 

--- a/src/pg/filter/getAst.js
+++ b/src/pg/filter/getAst.js
@@ -67,7 +67,7 @@ function construct(node, prop, op) {
 function simplify(node) {
   const op = node[0];
 
-  // TODO: $and/$or with multiple $subs with same prop -> 
+  // TODO: $and/$or with multiple $subs with same prop ->
   // single $sub with $and/$or inside
 
   // Recurse into subnodes and simplify them first.

--- a/src/pg/filter/getAst.js
+++ b/src/pg/filter/getAst.js
@@ -31,12 +31,6 @@ export default function getAst(filter) {
   return simplify(construct(filter));
 }
 
-/* construct() might need to give unique aliases to subqueries. We use
-   counter to just use consecutive numbers for this.
-
-   Important: The counter is best reset before calling construct() for the
-   root filter, but this must not happen during recursive calls. */
-
 function construct(node, prop, op) {
   if (!node || typeof node !== 'object' || (prop && op)) {
     if (op && prop) return [op, prop, node];
@@ -63,8 +57,7 @@ function construct(node, prop, op) {
         return construct(val, prop, key);
       }
       if (prop) {
-        if (key[0] === '.') return construct(val, prop + key);
-        throw Error(`pgast.unexpected_prop: ${key}`);
+        return ['$sub', prop, construct({ [key]: val })];
       }
       return construct(val, key);
     }),
@@ -74,11 +67,16 @@ function construct(node, prop, op) {
 function simplify(node) {
   const op = node[0];
 
+  // TODO: $and/$or with multiple $subs with same prop -> 
+  // single $sub with $and/$or inside
+
   // Recurse into subnodes and simplify them first.
   if (op === '$and' || op === '$or') {
     node[1] = node[1].map((subnode) => simplify(subnode));
   } else if (op === '$not') {
     node[1] = simplify(node[1]);
+  } else if (op === '$sub') {
+    node[2] = simplify(node[2]);
   }
 
   // Handle empty $and/$or and booleans

--- a/src/pg/filter/getSql.js
+++ b/src/pg/filter/getSql.js
@@ -74,24 +74,24 @@ function getNodeSql(ast, options) {
     if (!options.joins[joinName]) throw Error(`pg.no_join ${joinName}`);
     const { idCol } = options;
     const joinOptions = options.joins[joinName];
-    // console.log({ joinOptions });
     const { table: joinTable, refCol } = options.joins[joinName];
-    return sql`"${raw(idCol)}" IN (SELECT "${raw(refCol)}" FROM "${raw(joinTable)}" WHERE ${getNodeSql(ast[2], joinOptions)})`;
+    return sql`"${raw(idCol)}" IN (SELECT "${raw(refCol)}" FROM "${raw(
+      joinTable,
+    )}" WHERE ${getNodeSql(ast[2], joinOptions)})`;
   }
 
   // It is a binary operator
 
   const [prefix, ...suffix] = ast[1].split('.');
   const { types = {} } = options.schema;
-  console.log({ options });
   if (!types[prefix]) throw Error(`pg.no_column ${prefix}`);
 
   if (types[prefix] === 'jsonb') {
     const [lhs, textLhs] = suffix.length
       ? [
-        sql`"${raw(prefix)}" #> ${suffix}`,
-        sql`"${raw(prefix)}" #>> ${suffix}`,
-      ]
+          sql`"${raw(prefix)}" #> ${suffix}`,
+          sql`"${raw(prefix)}" #>> ${suffix}`,
+        ]
       : [sql`"${raw(prefix)}"`, sql`"${raw(prefix)}" #>> '{}'`];
 
     return getBinarySql(lhs, 'jsonb', op, ast[2], textLhs);
@@ -100,7 +100,6 @@ function getNodeSql(ast, options) {
     return getBinarySql(sql`"${raw(prefix)}"`, types[prefix], op, ast[2]);
   }
 }
-
 
 export default function getSql(filter, options) {
   const ast = getAst(filter);

--- a/src/pg/filter/getSql.js
+++ b/src/pg/filter/getSql.js
@@ -72,12 +72,12 @@ function getNodeSql(ast, options) {
     // Handle joins.
     const joinName = ast[1];
     if (!options.joins[joinName]) throw Error(`pg.no_join ${joinName}`);
-    const { idCol } = options;
+    const { idCol, schema } = options;
     const joinOptions = options.joins[joinName];
     const { table: joinTable, refCol } = options.joins[joinName];
-    return sql`"${raw(idCol)}" IN (SELECT "${raw(refCol)}" FROM "${raw(
-      joinTable,
-    )}" WHERE ${getNodeSql(ast[2], joinOptions)})`;
+    return sql`"${raw(idCol)}" IN (SELECT "${raw(refCol)}"::${raw(
+      schema.types[idCol],
+    )} FROM "${raw(joinTable)}" WHERE ${getNodeSql(ast[2], joinOptions)})`;
   }
 
   // It is a binary operator

--- a/src/pg/filter/getSql.js
+++ b/src/pg/filter/getSql.js
@@ -53,42 +53,56 @@ function getBinarySql(lhs, type, op, value, textLhs) {
   return sql`${lhs} ${sqlOp} ${value}`;
 }
 
-export default function getSql(filter, options) {
-  function getNodeSql(ast) {
-    if (typeof ast === 'boolean') return ast;
-    const op = ast[0];
+function getNodeSql(ast, options) {
+  if (typeof ast === 'boolean') return ast;
+  const op = ast[0];
 
-    if (op === '$and' || op === '$or') {
-      // Handle variadic operators
-      return sql`(${join(
-        ast[1].map((node) => getNodeSql(node)),
-        `) ${opSql[op]} (`,
-      )})`;
-    } else if (op === '$not') {
-      // Handle unary operators
-      return sql`${opSql[op]} (${getNodeSql(ast[1])})`;
-    }
-
-    // It is a binary operator
-
-    const [prefix, ...suffix] = ast[1].split('.');
-    const { types } = options.schema;
-    if (!types[prefix]) throw Error(`pg.no_column ${prefix}`);
-
-    if (types[prefix] === 'jsonb') {
-      const [lhs, textLhs] = suffix.length
-        ? [
-            sql`"${raw(prefix)}" #> ${suffix}`,
-            sql`"${raw(prefix)}" #>> ${suffix}`,
-          ]
-        : [sql`"${raw(prefix)}"`, sql`"${raw(prefix)}" #>> '{}'`];
-
-      return getBinarySql(lhs, 'jsonb', op, ast[2], textLhs);
-    } else {
-      if (suffix.length) throw Error(`pg.lookup_not_jsonb ${prefix}`);
-      return getBinarySql(sql`"${raw(prefix)}"`, types[prefix], op, ast[2]);
-    }
+  if (op === '$and' || op === '$or') {
+    // Handle variadic operators
+    return sql`(${join(
+      ast[1].map((node) => getNodeSql(node, options)),
+      `) ${opSql[op]} (`,
+    )})`;
+  } else if (op === '$not') {
+    // Handle unary operators
+    return sql`${opSql[op]} (${getNodeSql(ast[1], options)})`;
   }
 
-  return getNodeSql(getAst(filter));
+  if (op === '$sub') {
+    // Handle joins.
+    const joinName = ast[1];
+    if (!options.joins[joinName]) throw Error(`pg.no_join ${joinName}`);
+    const { idCol } = options;
+    const joinOptions = options.joins[joinName];
+    // console.log({ joinOptions });
+    const { table: joinTable, refCol } = options.joins[joinName];
+    return sql`"${raw(idCol)}" IN (SELECT "${raw(refCol)}" FROM "${raw(joinTable)}" WHERE ${getNodeSql(ast[2], joinOptions)})`;
+  }
+
+  // It is a binary operator
+
+  const [prefix, ...suffix] = ast[1].split('.');
+  const { types = {} } = options.schema;
+  console.log({ options });
+  if (!types[prefix]) throw Error(`pg.no_column ${prefix}`);
+
+  if (types[prefix] === 'jsonb') {
+    const [lhs, textLhs] = suffix.length
+      ? [
+        sql`"${raw(prefix)}" #> ${suffix}`,
+        sql`"${raw(prefix)}" #>> ${suffix}`,
+      ]
+      : [sql`"${raw(prefix)}"`, sql`"${raw(prefix)}" #>> '{}'`];
+
+    return getBinarySql(lhs, 'jsonb', op, ast[2], textLhs);
+  } else {
+    if (suffix.length) throw Error(`pg.lookup_not_jsonb ${prefix}`);
+    return getBinarySql(sql`"${raw(prefix)}"`, types[prefix], op, ast[2]);
+  }
+}
+
+
+export default function getSql(filter, options) {
+  const ast = getAst(filter);
+  return getNodeSql(ast, options);
 }

--- a/src/pg/index.js
+++ b/src/pg/index.js
@@ -6,7 +6,7 @@ import Db from './Db.js';
  *    table: string,
  *    idCol: string,
  *    verCol: string,
- *    joins: Record<string, TableOpts & { refCol: string }>,
+ *    joins: Record<string, Partial<TableOpts> & { refCol: string }>,
  *    schema?: any,
  *    verDefault?: string
  * }} TableOpts

--- a/src/pg/index.js
+++ b/src/pg/index.js
@@ -6,6 +6,11 @@ import Db from './Db.js';
  *    table?: string,
  *    idCol?: string,
  *    verCol?: string,
+ *    joins?: Record<string, {
+ *        table?: string,
+ *        refCol?: string,
+ *        verCol?: string,
+ *    }>
  *    connection?: any,
  *    schema?: any,
  *    verDefault?: string
@@ -13,18 +18,18 @@ import Db from './Db.js';
  * @returns
  */
 export const pg =
-  ({ table, idCol, verCol, connection, schema, verDefault }) =>
+  ({ table, idCol, verCol, joins, connection, schema, verDefault }) =>
   (store) => {
     store.on('read', read);
     store.on('write', write);
 
-    // TODO: Make the defaults smarter using introspection.
     const prefix = store.path;
     const tableOpts = {
       prefix,
       table: table || prefix[prefix.length - 1] || 'default',
       idCol: idCol || 'id',
       verCol: verCol || 'updatedAt',
+      joins: joins || {},
       schema,
       verDefault,
     };

--- a/src/pg/sql/getArgSql.js
+++ b/src/pg/sql/getArgSql.js
@@ -11,7 +11,7 @@ import { getJsonBuildTrusted, lookup } from './clauses.js';
   @param {{prefix: string, idCol: string, verDefault: string}} options
 
   @typedef { import('sql-template-tag').Sql } Sql
-  @return {{ meta: Sql, where: Sql[], order?: Sql, group?: Sql, limit: number }}
+  @return {{ meta: Sql, where: Sql[], order?: Sql, group?: Sql, limit: number, ensureSingleRow: boolean }}
 */
 export default function getArgSql(
   { $first, $last, $after, $before, $since, $until, $all, $cursor: _, ...rest },
@@ -40,7 +40,13 @@ export default function getArgSql(
 
   if (!isEmpty(filter)) where.push(getFilterSql(filter, options));
 
-  if (!hasRangeArg) return { meta: meta(baseKey), where, limit: 1 };
+  if (!hasRangeArg)
+    return {
+      meta: meta(baseKey),
+      where,
+      limit: 1,
+      ensureSingleRow: $group === true,
+    };
 
   const groupCols =
     Array.isArray($group) &&
@@ -89,6 +95,7 @@ export default function getArgSql(
     order,
     group,
     limit: $first || $last,
+    ensureSingleRow: true,
   };
 }
 

--- a/src/pg/sql/select.js
+++ b/src/pg/sql/select.js
@@ -6,9 +6,27 @@ import { getSelectCols } from './clauses.js';
 const MAX_LIMIT = 4096;
 
 export function selectByArgs(args, projection, options) {
-  const { table } = options;
-  const { where, order, group, limit, meta } = getArgSql(args, options);
+  const { table, idCol } = options;
+  const { where, order, group, limit, meta, ensureSingleRow } = getArgSql(
+    args,
+    options,
+  );
   const clampedLimit = Math.min(MAX_LIMIT, limit || MAX_LIMIT);
+
+  // We use an "id" = (... LIMIT 2) query to ensure an error is thrown if more
+  // the WHERE clause matches multiple rows.
+  if (!ensureSingleRow) {
+    return sql`
+      SELECT
+      ${getSelectCols(options, projection)}, ${meta}
+      FROM "${raw(table)}" WHERE "${raw(idCol)}" = (
+        SELECT "${raw(idCol)}" FROM "${raw(table)}"
+        ${where.length ? sql`WHERE ${join(where, ' AND ')}` : empty}
+        LIMIT 2
+      )
+    `;
+  }
+
   return sql`
     SELECT
     ${getSelectCols(options, projection)}, ${meta}

--- a/src/pg/sql/upsert.js
+++ b/src/pg/sql/upsert.js
@@ -15,14 +15,15 @@ function getSingleSql(arg, options) {
 
   const { where, meta } = getArgSql(arg, options);
   if (!where?.length) throw Error('pg_write.no_condition');
-  /* We use a subquery to ensure that only one object is ever updated.
-     Postgres doesn't support LIMIT on updates otherwise. */
+
+  // We use a subquery with limit 2 to ensure an error is thrown if the filter
+  // matches multiple rows.
   return {
     where: sql`"${raw(idCol)}" = (
         SELECT "${raw(idCol)}"
         FROM "${raw(table)}"
         WHERE ${join(where, ' AND ')}
-        LIMIT 1
+        LIMIT 2
       )`,
     meta,
   };

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -987,7 +987,13 @@ describe('pg_e2e', () => {
     expect(res).toEqual({ settings: null });
   });
 
-  // describe('join', () => {
-  //   beforeEach()
-  // });
+  describe('join', () => {
+    test('simple_join', async () => {
+      const res = await store.read('users', {
+        $key: { posts: { title: { $ire: 'foo' } } },
+        name: true,
+      });
+      expect(res).toEqual('rst');
+    });
+  });
 });

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -15,16 +15,16 @@ const uuidV4Regex =
 
 jest.setTimeout(30000);
 
+beforeAll(async () => {
+  await setupPgServer();
+});
+
+afterAll(async () => {
+  await teardownPgServer();
+});
+
 describe('pg_e2e', () => {
   let store;
-
-  beforeAll(async () => {
-    await setupPgServer();
-  });
-
-  afterAll(async () => {
-    await teardownPgServer();
-  });
 
   beforeEach(async () => {
     await resetTables();
@@ -35,6 +35,13 @@ describe('pg_e2e', () => {
         table: 'users',
         idCol: 'id',
         verCol: 'version',
+        joins: {
+          posts: {
+            table: 'posts',
+            refCol: 'authorId',
+            verCol: 'version',
+          },
+        },
         connection: getPool(),
       }),
     );
@@ -896,7 +903,6 @@ describe('pg_e2e', () => {
 
   describe('json_lookup_and_operators', () => {
     beforeEach(async () => {
-      await resetTables();
       await store.write('users', [
         {
           $key: uuid(),
@@ -980,4 +986,8 @@ describe('pg_e2e', () => {
 
     expect(res).toEqual({ settings: null });
   });
+
+  // describe('join', () => {
+  //   beforeEach()
+  // });
 });

--- a/src/pg/test/filter/getSql.test.js
+++ b/src/pg/test/filter/getSql.test.js
@@ -100,16 +100,17 @@ test('join', () => {
       { posts: { category: 'programming' } },
       {
         idCol: 'id',
+        schema: { types: { id: 'uuid' } },
         joins: {
           posts: {
             table: 'posts',
             refCol: 'authorId',
-            schema: { types: { category: 'text' } },
+            schema: { types: { category: 'text', authorId: 'text' } },
           },
         },
       },
     ),
   ).toEqual(
-    sql`"id" IN (SELECT "authorId" FROM "posts" WHERE "category" = ${'programming'})`,
+    sql`"id" IN (SELECT "authorId"::uuid FROM "posts" WHERE "category" = ${'programming'})`,
   );
 });

--- a/src/pg/test/filter/getSql.test.js
+++ b/src/pg/test/filter/getSql.test.js
@@ -95,13 +95,21 @@ test('jsonb eq text', () => {
 });
 
 test('join', () => {
-  expect(getSql(
-    { posts: { category: 'programming' } },
-    {
-      idCol: 'id',
-      joins: { posts: { table: 'posts', refCol: 'authorId', schema: { types: { category: 'text' } } } },
-    }
-  )).toEqual(
-    sql`"id" IN (SELECT "authorId" FROM "posts" WHERE "category" = ${'programming'})`
-  )
+  expect(
+    getSql(
+      { posts: { category: 'programming' } },
+      {
+        idCol: 'id',
+        joins: {
+          posts: {
+            table: 'posts',
+            refCol: 'authorId',
+            schema: { types: { category: 'text' } },
+          },
+        },
+      },
+    ),
+  ).toEqual(
+    sql`"id" IN (SELECT "authorId" FROM "posts" WHERE "category" = ${'programming'})`,
+  );
 });

--- a/src/pg/test/filter/getSql.test.js
+++ b/src/pg/test/filter/getSql.test.js
@@ -93,3 +93,15 @@ test('jsonb eq text', () => {
     sql`"data" #>> ${['Name']} = ${'Bob'}`,
   );
 });
+
+test('join', () => {
+  expect(getSql(
+    { posts: { category: 'programming' } },
+    {
+      idCol: 'id',
+      joins: { posts: { table: 'posts', refCol: 'authorId', schema: { types: { category: 'text' } } } },
+    }
+  )).toEqual(
+    sql`"id" IN (SELECT "authorId" FROM "posts" WHERE "category" = ${'programming'})`
+  )
+});

--- a/src/pg/test/sql/select.test.js
+++ b/src/pg/test/sql/select.test.js
@@ -59,7 +59,10 @@ describe('select_sql', () => {
       SELECT *, ${JSON.stringify({ email: 'abc@foo.com' })}::jsonb AS "$key",
       current_timestamp AS "$ver",
       array[ ${'user'}::text, "id" ]::text[] AS "$ref"
-      FROM "user" WHERE "email" = ${'abc@foo.com'} LIMIT ${1}
+      FROM "user" WHERE "id" = (
+        SELECT "id" FROM "user" WHERE "email" = ${'abc@foo.com'}
+        LIMIT 2
+      )
     `;
     expectSql(selectByArgs(arg, null, options), expectedResult);
   });

--- a/src/pg/test/sql/upsert.test.js
+++ b/src/pg/test/sql/upsert.test.js
@@ -124,7 +124,7 @@ describe('byArg', () => {
         "name" = ${'hello'},
         "email" = ${'world'},
         "version" =  default
-      WHERE "id" = (SELECT "id" FROM "post" WHERE "email" = ${'world'} LIMIT 1)
+      WHERE "id" = (SELECT "id" FROM "post" WHERE "email" = ${'world'} LIMIT 2)
       RETURNING *,
         ${'{"email":"world"}'}::jsonb AS "$key",
         current_timestamp AS "$ver",


### PR DESCRIPTION
See the changes to Readme.md for documentation.

### Changes
- Add an AST node type `$sub`, which creates a "named context" for evaluating child expressions. For subqueries, this will be the name of the joined table
- Generate SQL subqueries when the $sub AST node is encountered
- Add option parsing and schema introspection for all the joined tables

