### PR TITLE
Add json path operators

### DIFF
--- a/src/pg/filter/getAst.js
+++ b/src/pg/filter/getAst.js
@@ -14,6 +14,8 @@ const valid = {
   $has: true,
   $cts: true,
   $ctd: true,
+  $keycts: true,
+  $keyctd: true,
 };
 
 const inverse = {

--- a/src/pg/filter/getSql.js
+++ b/src/pg/filter/getSql.js
@@ -48,7 +48,7 @@ function getBinarySql(lhs, type, op, value, textLhs) {
       return sql`${textLhs} ${sqlOp} ${value}`;
     }
     if ((op === '$keycts' || op === '$keyctd') && Array.isArray(value))
-        return sql`${lhs} ${sqlOp} array[${join(value)}]`;
+        return sql`${lhs} ${sqlOp} ${value}::text[]`;
     return sql`${lhs} ${sqlOp} ${JSON.stringify(value)}::jsonb`;
   }
 

--- a/src/pg/filter/getSql.js
+++ b/src/pg/filter/getSql.js
@@ -48,7 +48,7 @@ function getBinarySql(lhs, type, op, value, textLhs) {
       return sql`${textLhs} ${sqlOp} ${value}`;
     }
     if ((op === '$keycts' || op === '$keyctd') && Array.isArray(value))
-        return sql`${lhs} ${sqlOp} ${value}::text[]`;
+      return sql`${lhs} ${sqlOp} ${value}::text[]`;
     return sql`${lhs} ${sqlOp} ${JSON.stringify(value)}::jsonb`;
   }
 

--- a/src/pg/filter/getSql.js
+++ b/src/pg/filter/getSql.js
@@ -18,6 +18,8 @@ const opSql = {
   $ire: sql`~*`,
   $cts: sql`@>`,
   $ctd: sql`<@`,
+  $keycts: sql`?|`,
+  $keyctd: sql`?&`,
 };
 
 function getBinarySql(lhs, type, op, value, textLhs) {
@@ -45,6 +47,8 @@ function getBinarySql(lhs, type, op, value, textLhs) {
     if (typeof value === 'string') {
       return sql`${textLhs} ${sqlOp} ${value}`;
     }
+    if ((op === '$keycts' || op === '$keyctd') && Array.isArray(value))
+        return sql`${lhs} ${sqlOp} array[${join(value)}]`;
     return sql`${lhs} ${sqlOp} ${JSON.stringify(value)}::jsonb`;
   }
 

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1133,8 +1133,7 @@ describe('pg_e2e', () => {
         },
         name: true,
       });
-      const expected = page([], ...); // Add pagination props
-      expect(res1).toEqual(expected);
+      expect(JSON.stringify(res1)).toBe(JSON.stringify([]));
       const res2 = await store.read('users', {
         $key: {
           settings: {

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1133,7 +1133,8 @@ describe('pg_e2e', () => {
         },
         name: true,
       });
-      expect(JSON.stringify(res1)).toBe(JSON.stringify([]));
+      const expected = page([], ...); // Add pagination props
+      expect(res1).toEqual(expected);
       const res2 = await store.read('users', {
         $key: {
           settings: {

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1133,7 +1133,17 @@ describe('pg_e2e', () => {
         },
         name: true,
       });
-      expect(JSON.stringify(res1)).toBe(JSON.stringify([]));
+      const expected = page(
+        {
+          settings: {
+            $keyctd: ['foo', 'bar'],
+          },
+          $order: ['name'],
+        },
+        null,
+        [],
+      );
+      expect(res1).toEqual(expected);
       const res2 = await store.read('users', {
         $key: {
           settings: {

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1049,7 +1049,7 @@ describe('pg_e2e', () => {
       );
     });
   });
-  describe('jsonpath operators', () => {
+  describe('json key existence operators', () => {
     const uidA = uuid();
     const uidB = uuid();
     beforeEach(async () => {

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1059,7 +1059,7 @@ describe('pg_e2e', () => {
         settings: { foo: 3 },
         $put: true,
       });
-     await store.write(['users', uidB], {
+      await store.write(['users', uidB], {
         name: 'bob',
         email: 'bob@acme.co',
         settings: { bar: 5 },
@@ -1071,65 +1071,65 @@ describe('pg_e2e', () => {
       const res1 = await store.read('users', {
         $key: {
           settings: {
-            $keycts: ['foo', 'bar']
+            $keycts: ['foo', 'bar'],
           },
           $order: ['name'],
-          $all: true
+          $all: true,
         },
         name: true,
       });
       const exp1 = page(
-          {
-            settings: {
-              $keycts: ['foo', 'bar']
-            },
-           $order: ['name']
+        {
+          settings: {
+            $keycts: ['foo', 'bar'],
           },
-          null,
-          [
-            keyref(
-                {
-                  settings: {
-                    $keycts: ['foo', 'bar']
-                  },
-                  $order:['name'],
-                  $cursor: [expect.any(String)],
-                },
-                expect.any(Array),
-                { name: 'alice' },
-            ),
-            keyref(
-                {
-                  settings: {
-                    $keycts: ['foo', 'bar']
-                  },
-                  $order:['name'],
-                  $cursor: [expect.any(String)],
-                },
-                expect.any(Array),
-                { name: 'bob' },
-            ),
-          ],
+          $order: ['name'],
+        },
+        null,
+        [
+          keyref(
+            {
+              settings: {
+                $keycts: ['foo', 'bar'],
+              },
+              $order: ['name'],
+              $cursor: [expect.any(String)],
+            },
+            expect.any(Array),
+            { name: 'alice' },
+          ),
+          keyref(
+            {
+              settings: {
+                $keycts: ['foo', 'bar'],
+              },
+              $order: ['name'],
+              $cursor: [expect.any(String)],
+            },
+            expect.any(Array),
+            { name: 'bob' },
+          ),
+        ],
       );
       expect(res1).toEqual(exp1);
       const res2 = await store.read('users', {
         $key: {
           settings: {
-            $keycts: ['foo']
+            $keycts: ['foo'],
           },
         },
         name: true,
       });
-      expect(res2).toEqual([{name: 'alice'}]);
+      expect(res2).toEqual([{ name: 'alice' }]);
     });
     test('keyctd', async () => {
       const res1 = await store.read('users', {
         $key: {
           settings: {
-            $keyctd: ['foo', 'bar']
+            $keyctd: ['foo', 'bar'],
           },
           $order: ['name'],
-          $all: true
+          $all: true,
         },
         name: true,
       });
@@ -1137,12 +1137,12 @@ describe('pg_e2e', () => {
       const res2 = await store.read('users', {
         $key: {
           settings: {
-            $keyctd: ['foo']
+            $keyctd: ['foo'],
           },
         },
         name: true,
       });
-      expect(res2).toEqual([{name: 'alice'}]);
+      expect(res2).toEqual([{ name: 'alice' }]);
     });
   });
 });

--- a/src/pg/test/filter/getSql.test.js
+++ b/src/pg/test/filter/getSql.test.js
@@ -118,23 +118,19 @@ test('join', () => {
 test('keycts', () => {
   const value = ['foo@bar.com', 'foo@baz.com'];
   expect(
-      getSql(
-          { emails: { $keycts: ['foo@bar.com', 'foo@baz.com'] } },
-          opt({ emails: 'jsonb' }),
-      ),
-  ).toEqual(
-      sql`"emails" ?| ${value}::text[]`,
-  );
+    getSql(
+      { emails: { $keycts: ['foo@bar.com', 'foo@baz.com'] } },
+      opt({ emails: 'jsonb' }),
+    ),
+  ).toEqual(sql`"emails" ?| ${value}::text[]`);
 });
 
 test('keyctd', () => {
   const value = ['foo@bar.com', 'foo@baz.com'];
   expect(
-      getSql(
-          { emails: { $keyctd: ['foo@bar.com', 'foo@baz.com'] } },
-          opt({ emails: 'jsonb' }),
-      ),
-  ).toEqual(
-      sql`"emails" ?& ${value}::text[]`,
-  );
+    getSql(
+      { emails: { $keyctd: ['foo@bar.com', 'foo@baz.com'] } },
+      opt({ emails: 'jsonb' }),
+    ),
+  ).toEqual(sql`"emails" ?& ${value}::text[]`);
 });

--- a/src/pg/test/filter/getSql.test.js
+++ b/src/pg/test/filter/getSql.test.js
@@ -116,23 +116,25 @@ test('join', () => {
 });
 
 test('keycts', () => {
+  const value = ['foo@bar.com', 'foo@baz.com'];
   expect(
       getSql(
           { emails: { $keycts: ['foo@bar.com', 'foo@baz.com'] } },
           opt({ emails: 'jsonb' }),
       ),
   ).toEqual(
-      sql`"emails" ?| array[${join(['foo@bar.com', 'foo@baz.com'])}]`,
+      sql`"emails" ?| ${value}::text[]`,
   );
 });
 
 test('keyctd', () => {
+  const value = ['foo@bar.com', 'foo@baz.com'];
   expect(
       getSql(
           { emails: { $keyctd: ['foo@bar.com', 'foo@baz.com'] } },
           opt({ emails: 'jsonb' }),
       ),
   ).toEqual(
-      sql`"emails" ?& array[${join(['foo@bar.com', 'foo@baz.com'])}]`,
+      sql`"emails" ?& ${value}::text[]`,
   );
 });

--- a/src/pg/test/filter/getSql.test.js
+++ b/src/pg/test/filter/getSql.test.js
@@ -114,3 +114,25 @@ test('join', () => {
     sql`"id" IN (SELECT "authorId"::uuid FROM "posts" WHERE "category" = ${'programming'})`,
   );
 });
+
+test('keycts', () => {
+  expect(
+      getSql(
+          { emails: { $keycts: ['foo@bar.com', 'foo@baz.com'] } },
+          opt({ emails: 'jsonb' }),
+      ),
+  ).toEqual(
+      sql`"emails" ?| array[${join(['foo@bar.com', 'foo@baz.com'])}]`,
+  );
+});
+
+test('keyctd', () => {
+  expect(
+      getSql(
+          { emails: { $keyctd: ['foo@bar.com', 'foo@baz.com'] } },
+          opt({ emails: 'jsonb' }),
+      ),
+  ).toEqual(
+      sql`"emails" ?& array[${join(['foo@bar.com', 'foo@baz.com'])}]`,
+  );
+});


### PR DESCRIPTION
This PR adds support for 2 new operators:

1. `?|` as `$keycts`
2. `?&` as `$keyctd`

Please see [this](https://www.postgresql.org/docs/12/functions-json.html) for more details about this operators.