### PR TITLE
explicitly pass text and name to pg client query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 dist
 .tsbuildinfo
+.next
 
 # misc
 .DS_Store

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -59,7 +59,11 @@ export default class Db {
           return types.getTypeParser(oid, format);
         },
       };
-      return await this.client.query({ ...sql, text: sql.text, name: sql.name });
+      return await this.client.query({
+        ...sql,
+        text: sql.text,
+        name: sql.name,
+      });
     } catch (e) {
       const message = [
         e.message,

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -62,7 +62,7 @@ export default class Db {
       return await this.client.query({
         ...sql,
         text: sql.text,
-        name: sql.name,
+        sql: sql.sql,
       });
     } catch (e) {
       const message = [

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -59,7 +59,7 @@ export default class Db {
           return types.getTypeParser(oid, format);
         },
       };
-      return await this.client.query(sql);
+      return await this.client.query({ ...sql, text: sql.text, name: sql.name });
     } catch (e) {
       const message = [
         e.message,


### PR DESCRIPTION
The `sql` param is actually an `sql-template-tag` string literal, which has property `text` and `name` as a `[Getter]`.

From node_modules/@graffy/pg/index.cjs:639
```js
Sql {
     values: [ 'adminSession', [length]: 1 ],
     strings:
      [ '\n        SELECT table_schema\n        FROM information_schema.tables\n        WHERE table_name = ',
        '\n        ORDER BY array_position(current_schemas(false)::text[], table_schema::text) ASC\n        LIMIT 1',
        [length]: 2 ],
     types:
      { getTypeParser: { [Function: getTypeParser] [length]: 2, [name]: 'getTypeParser' } },
     [text]: [Getter],
     [sql]: [Getter] } }
```


And when we pass the `sql` to `this.client.query()`, these getter properties are lost.

From node_modules/pg/lib/client.js:519
```js
Query {
  [domain]: null,
  _events: [Object: null prototype] {},
  _eventsCount: 0,
  _maxListeners: undefined,
  text: undefined,
  values: [ 'adminSession', [length]: 1 ],
  rows: undefined,
  types:
   { getTypeParser: { [Function: getTypeParser] [length]: 2, [name]: 'getTypeParser' } },
  name: undefined,
  binary: undefined,
  portal: '',
  callback: { [Function (anonymous)] [length]: 2, [name]: '' },
  _rowMode: undefined,
  _result:
   Result {
     command: null,
     rowCount: null,
     oid: null,
     rows: [ [length]: 0 ],
     fields: [ [length]: 0 ],
     _parsers: undefined,
     _types:
      { getTypeParser: { [Function: getTypeParser] [length]: 2, [name]: 'getTypeParser' } },
     RowCtor: null,
     rowAsArray: false },
  _results:
   Result {
     command: null,
     rowCount: null,
     oid: null,
     rows: [ [length]: 0 ],
     fields: [ [length]: 0 ],
     _parsers: undefined,
     _types:
      { getTypeParser: { [Function: getTypeParser] [length]: 2, [name]: 'getTypeParser' } },
     RowCtor: null,
     rowAsArray: false },
  isPreparedStatement: false,
  _canceledDueToError: false,
  _promise: null,
  [Symbol(kCapture)]: false }
```


This is even though the `getter` is called in [node-postgres/packages/pg/lib/query.js](https://github.com/brianc/node-postgres/blob/735683c5cb41bcbf043c6490be4b7f38cfe3ac48/packages/pg/lib/query.js#LL14C23-L14C23).

When I `console.log` above this line, the `text: [Getter]` is missing, and hence it's value.

I don't know how the Getter is being lost in the process, but this fixes the following error

```js
A query must have either text or a name. Supplying neither is unsupported.
```
coming from [here](https://github.com/brianc/node-postgres/blob/735683c5cb41bcbf043c6490be4b7f38cfe3ac48/packages/pg/lib/query.js#L152)