### PR TITLE
Insert mulpitle rows with one statement, where possible

### DIFF
--- a/src/core/test/porcelain.test.js
+++ b/src/core/test/porcelain.test.js
@@ -1,7 +1,7 @@
-import { jest } from '@jest/globals';
-import Graffy from '../Graffy.js';
 import GraffyFill from '@graffy/fill';
 import { page, ref } from '@graffy/testing';
+import { jest } from '@jest/globals';
+import Graffy from '../Graffy.js';
 
 test('Porcelain read', async () => {
   const store = new Graffy();
@@ -402,4 +402,18 @@ test('onReadWithNext', async () => {
       },
     },
   });
+});
+
+test('modified_next_options', async () => {
+  // @ts-ignore bad jest mockResolvedValue definitions?
+  const mockOnRead = jest.fn().mockResolvedValue({ 123: { name: 'Alice' } });
+  const query = { 123: { name: true } };
+  const store = new Graffy();
+  store.use(GraffyFill());
+  store.onRead('user', (query, _options, next) => {
+    return next(query, { bar: true });
+  });
+  store.onRead('user', mockOnRead);
+  await store.read('user', query, { foo: 2 });
+  expect(mockOnRead).toBeCalledWith(query, { bar: true }, expect.any(Function));
 });

--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -128,8 +128,7 @@ export const getInsert = (rows, options) => {
 
   const vals = [];
   for (const row of rows) {
-    const rowVals = Array(cols.length).fill(null);
-    rowVals[colIx[verCol]] = sql`default`;
+    const rowVals = Array(cols.length).fill(sql`default`);
 
     for (const col of cols) {
       if (col === verCol || !(col in row)) continue;

--- a/src/pg/test/sql/clauses.test.js
+++ b/src/pg/test/sql/clauses.test.js
@@ -1,26 +1,38 @@
 import sql from 'sql-template-tag';
-import expectSql from '../expectSql';
 import {
   getInsert,
-  getUpdates,
   getJsonBuildTrusted,
   getSelectCols,
+  getUpdates,
 } from '../../sql/clauses';
+import expectSql from '../expectSql';
 
 describe('clauses', () => {
-  const data = { a: 1, b: 1 };
-
   test('insert', () => {
-    const { cols, vals } = getInsert(data, {
+    const data = [
+      { a: 1, b: 1 },
+      { a: 2, b: 2 },
+    ];
+
+    const { cols, vals, updates } = getInsert(data, {
       verCol: 'version',
       schema: { types: { a: 'int8', b: 'float', version: 'int8' } },
       verDefault: 'current_timestamp',
     });
     expectSql(cols, sql`"a", "b", "version"`);
-    expectSql(vals, sql`${data.a} , ${data.b} , default`);
+    expectSql(
+      vals,
+      sql`(${data[0].a} , ${data[0].b} , default), (${data[1].a} , ${data[1].b} , default)`,
+    );
+    expectSql(
+      updates,
+      sql`"a" = "excluded"."a", "b" = "excluded"."b", "version" = "excluded"."version"`,
+    );
   });
 
   test('updates', () => {
+    const data = { a: 1, b: 1 };
+
     const options = {
       idCol: 'id',
       verCol: 'version',

--- a/src/pg/test/sql/upsert.test.js
+++ b/src/pg/test/sql/upsert.test.js
@@ -1,4 +1,4 @@
-import { put, patch } from '../../sql/upsert.js';
+import { patch, put } from '../../sql/upsert.js';
 
 import sql from 'sql-template-tag';
 import expectSql from '../expectSql.js';
@@ -25,27 +25,31 @@ const options = {
 
 describe('byId', () => {
   test('put', async () => {
+    const sqls = put(
+      [
+        [
+          {
+            $put: true,
+            id: 'post22',
+            type: 'post',
+            name: 'hello',
+            email: 'world',
+            config: { foo: 3 },
+            tags: [1, 2],
+          },
+          'post22',
+        ],
+      ],
+      options,
+    );
     expectSql(
-      put(
-        {
-          $put: true,
-          id: 'post22',
-          type: 'post',
-          name: 'hello',
-          email: 'world',
-          config: { foo: 3 },
-          tags: [1, 2],
-        },
-        'post22',
-        options,
-      ),
-      sql`INSERT INTO "post" ("id", "type", "name", "email", "config", "tags", "version")
-      VALUES (${'post22'}, ${'post'}, ${'hello'},${'world'},
+      sqls[0],
+      sql`INSERT INTO "post" ("id", "name", "type", "email", "config", "tags", "version")
+      VALUES (${'post22'}, ${'hello'}, ${'post'}, ${'world'},
       ${JSON.stringify({ foo: 3 })}, ${JSON.stringify([1, 2])}, default)
-      ON CONFLICT ("id") DO UPDATE SET ("id", "type", "name", "email", "config", "tags", "version")
-        = (${'post22'}, ${'post'}, ${'hello'},${'world'},
-        ${JSON.stringify({ foo: 3 })},
-        ${JSON.stringify([1, 2])}, default)
+      ON CONFLICT ("id") DO UPDATE SET "id" = "excluded"."id", "name" = "excluded"."name",
+        "type" = "excluded"."type", "email" = "excluded"."email", "config" = "excluded"."config",
+        "tags" = "excluded"."tags", "version" = "excluded"."version"
       RETURNING *, "id" AS "$key", current_timestamp AS "$ver"
     `,
     );
@@ -84,22 +88,27 @@ describe('byId', () => {
 
 describe('byArg', () => {
   test('put', async () => {
+    const sqls = put(
+      [
+        [
+          {
+            $put: true,
+            id: 'post22',
+            type: 'post',
+            name: 'hello',
+            email: 'world',
+          },
+          { email: 'world' },
+        ],
+      ],
+      options,
+    );
     expectSql(
-      put(
-        {
-          $put: true,
-          id: 'post22',
-          type: 'post',
-          name: 'hello',
-          email: 'world',
-        },
-        { email: 'world' },
-        options,
-      ),
-      sql`INSERT INTO "post" ("id", "type", "name", "email", "version")
-      VALUES (${'post22'}, ${'post'}, ${'hello'},${'world'}, default)
-      ON CONFLICT ("email") DO UPDATE SET ("id", "type", "name", "email", "version")
-        = (${'post22'}, ${'post'}, ${'hello'},${'world'},  default)
+      sqls[0],
+      sql`INSERT INTO "post" ("id", "name", "type", "email", "version")
+      VALUES (${'post22'}, ${'hello'}, ${'post'}, ${'world'}, default)
+      ON CONFLICT ("email") DO UPDATE SET "id" = "excluded"."id", "name" = "excluded"."name",
+      "type" = "excluded"."type", "email" = "excluded"."email", "version" = "excluded"."version"
       RETURNING *,
         ${'{"email":"world"}'}::jsonb AS "$key",
         current_timestamp AS "$ver",

--- a/src/pg/test/sql/upsert.test.js
+++ b/src/pg/test/sql/upsert.test.js
@@ -55,6 +55,51 @@ describe('byId', () => {
     );
   });
 
+  test('put_multi', async () => {
+    const sqls = put(
+      [
+        [
+          {
+            $put: true,
+            id: 'post22',
+            type: 'post',
+            name: 'hello',
+            email: 'world',
+            config: { foo: 3 },
+            tags: [1, 2],
+          },
+          'post22',
+        ],
+        [
+          {
+            $put: true,
+            id: 'post24',
+            type: 'post',
+            name: 'hi there',
+            email: 'mars',
+            config: { foo: 8 },
+            tags: [0, 9],
+          },
+          'post24',
+        ],
+      ],
+      options,
+    );
+    expectSql(
+      sqls[0],
+      sql`INSERT INTO "post" ("id", "name", "type", "email", "config", "tags", "version")
+      VALUES (${'post22'}, ${'hello'}, ${'post'}, ${'world'},
+      ${JSON.stringify({ foo: 3 })}, ${JSON.stringify([1, 2])}, default),
+      (${'post24'}, ${'hi there'}, ${'post'}, ${'mars'},
+      ${JSON.stringify({ foo: 8 })}, ${JSON.stringify([0, 9])}, default)
+      ON CONFLICT ("id") DO UPDATE SET "id" = "excluded"."id", "name" = "excluded"."name",
+        "type" = "excluded"."type", "email" = "excluded"."email", "config" = "excluded"."config",
+        "tags" = "excluded"."tags", "version" = "excluded"."version"
+      RETURNING *, "id" AS "$key", current_timestamp AS "$ver"
+    `,
+    );
+  });
+
   test('patch', async () => {
     expectSql(
       patch(


### PR DESCRIPTION
`graffy.write()` calls with multiple items being written by ID and with $put: true will now use a more efficient query.

A similar optimization is possible when $put is false, this will be done in a future release.