### PR TITLE
Aravind/skip unchanged encode

### DIFF
--- a/scripts/version.js
+++ b/scripts/version.js
@@ -15,12 +15,16 @@ export default async function version(str) {
   try {
     const { stdout } = await git('tag');
 
+    console.log(stdout);
+
     const [major = 0, minor = 0, patch = 0, pre = '', number = 0] = stdout
       .split('\n')
       .reduce((latest, vstring) => {
         const version = vstring
           .split(/[.-]/)
-          .map((seg) => (Number.isNaN(seg) ? seg : parseInt(seg)));
+          .map((seg, i) => (i === 3 ? seg : parseInt(seg)));
+
+        console.log('latest', latest, vstring, version);
 
         for (let i = 0; i < 5; i++) {
           const atPre = i === 3;
@@ -31,6 +35,8 @@ export default async function version(str) {
         }
         return latest;
       }, []);
+
+    console.log({ major, minor, patch, pre, number });
 
     switch (str) {
       case 'major':

--- a/src/core/Graffy.js
+++ b/src/core/Graffy.js
@@ -16,6 +16,8 @@ import Core from './Core.js';
 import { shiftGen, wrapProvider } from './shift.js';
 import { validateCall, validateOn } from './validate.js';
 
+export { unchanged } from './shift.js';
+
 export default class Graffy {
   constructor(path = [], core = new Core()) {
     this.core = core;

--- a/src/core/Graffy.js
+++ b/src/core/Graffy.js
@@ -13,7 +13,7 @@ import {
 } from '@graffy/common';
 import { makeStream, mapStream } from '@graffy/stream';
 import Core from './Core.js';
-import { shiftGen, wrapProvider } from './shift.js';
+import { shiftGen, unchanged, wrapProvider } from './shift.js';
 import { validateCall, validateOn } from './validate.js';
 
 export { unchanged } from './shift.js';
@@ -106,3 +106,5 @@ export default class Graffy {
     return unwrapObject(decodeGraph(writtenChange), path);
   }
 }
+
+Graffy.unchanged = unchanged;


### PR DESCRIPTION
A lot of pass-through providers don't modify the payload or the return value. Unfortunately Graffy must always assume that it has, which leads to many wasted CPU cycles encoding and decoding things.

This adds an explicit "unchanged" symbol that providers can pass to allow skipping encode.