### PR TITLE
Inspection in Graffy PG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ npm-debug.log*
 .idea
 *.code-workspace
 *.sublime-*
+
+scratch.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-dom": "^18.3.1",
         "react-test-renderer": "^18.3.1",
         "rimraf": "^5.0.5",
+        "sql-formatter": "^15.6.2",
         "sql-template-tag": "^5.2.1",
         "typescript": "^5.4.5",
         "uuid": "^9.0.0",
@@ -3276,6 +3277,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3623,6 +3631,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -6132,6 +6147,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6164,6 +6186,29 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -7163,6 +7208,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7342,6 +7408,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/rimraf": {
@@ -7764,6 +7840,27 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sql-formatter": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.6.2.tgz",
+      "integrity": "sha512-ZjqOfJGuB97UeHzTJoTbadlM0h9ynehtSTHNUbGfXR4HZ4rCIoD2oIW91W+A5oE76k8hl0Uz5GD8Sx3Pt9Xa3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "nearley": "^2.20.1"
+      },
+      "bin": {
+        "sql-formatter": "bin/sql-formatter-cli.cjs"
+      }
+    },
+    "node_modules/sql-formatter/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/sql-template-tag": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "pg:clean": "docker rm -f graffypg",
     "pg:psql": "docker run --name pgrepl -e POSTGRES_PASSWORD=graffy -d postgres:alpine && until docker exec -it pgrepl psql -U postgres; do sleep 0.5; done ; docker rm -f pgrepl"
   },
-  "workspaces": [
-    "src/*"
-  ],
+  "workspaces": ["src/*"],
   "author": "aravindet",
   "license": "Apache-2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "pg:clean": "docker rm -f graffypg",
     "pg:psql": "docker run --name pgrepl -e POSTGRES_PASSWORD=graffy -d postgres:alpine && until docker exec -it pgrepl psql -U postgres; do sleep 0.5; done ; docker rm -f pgrepl"
   },
-  "workspaces": ["src/*"],
+  "workspaces": [
+    "src/*"
+  ],
   "author": "aravindet",
   "license": "Apache-2.0",
   "bugs": {
@@ -49,6 +51,7 @@
     "react-dom": "^18.3.1",
     "react-test-renderer": "^18.3.1",
     "rimraf": "^5.0.5",
+    "sql-formatter": "^15.6.2",
     "sql-template-tag": "^5.2.1",
     "typescript": "^5.4.5",
     "uuid": "^9.0.0",

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -19,9 +19,17 @@ import debug from 'debug';
 import pg from 'pg';
 import sqlTag, { join as sqlJoin } from 'sql-template-tag';
 import formatSql from './sql/format.js';
+import { format } from 'sql-formatter';
 import { del, patch, put, selectByArgs, selectByIds } from './sql/index.js';
 const log = debug('graffy:pg:db');
 const { Pool, Client, types } = pg;
+
+const formatSqlValue = (value) =>
+  typeof value === 'number'
+    ? value.toString()
+    : typeof value === 'object'
+      ? `'${JSON.stringify(value)}'`
+      : `'${value}'`;
 
 export default class Db {
   constructor(connection) {
@@ -179,10 +187,10 @@ export default class Db {
     };
 
     const explainArgs = async (args, projection) => {
-      const { $analyze, ...qArgs } = args.$explain;
+      const { analyze, $explain: qArgs } = args;
       const qSql = selectByArgs(qArgs, null, tableOptions);
       const sql = sqlTag`EXPLAIN (${
-        $analyze ? sqlTag`ANALYZE, BUFFERS, TIMING, ` : sqlTag``
+        analyze ? sqlTag`ANALYZE, BUFFERS, TIMING, ` : sqlTag``
       }COSTS, VERBOSE, FORMAT JSON) ${qSql}`;
       const result = await this.readSql(sql, tableOptions);
       const wrappedGraph = encodeGraph(

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -17,7 +17,7 @@ import {
 } from '@graffy/common';
 import debug from 'debug';
 import pg from 'pg';
-import sqlTag from 'sql-template-tag';
+import sqlTag, { join as sqlJoin } from 'sql-template-tag';
 import formatSql from './sql/format.js';
 import { del, patch, put, selectByArgs, selectByIds } from './sql/index.js';
 const log = debug('graffy:pg:db');
@@ -172,16 +172,30 @@ export default class Db {
 
     const getByArgs = async (args, projection) => {
       const sql = selectByArgs(args, projection, tableOptions);
-      // console.log('SQL', sql);
       const result = await this.readSql(sql, tableOptions);
-      if (projection.$sql) {
-        for (const object of result) {
-          object.$sql = formatSql(sql);
-        }
-      }
-      // console.log('Result', result);
       const wrappedGraph = encodeGraph(wrapObject(result, rawPrefix));
       log('getByArgs', wrappedGraph);
+      merge(results, wrappedGraph);
+    };
+
+    const explainArgs = async (args, projection) => {
+      const { $analyze, ...qArgs } = args.$explain;
+      const qSql = selectByArgs(qArgs, null, tableOptions);
+      const sql = sqlTag`EXPLAIN (${
+        $analyze ? sqlTag`ANALYZE, BUFFERS, TIMING, ` : sqlTag``
+      }COSTS, VERBOSE, FORMAT JSON) ${qSql}`;
+      const result = await this.readSql(sql, tableOptions);
+      const wrappedGraph = encodeGraph(
+        wrapObject(
+          {
+            $key: args,
+            sql: formatSql(qSql),
+            plan: result[0]['QUERY PLAN'][0],
+          },
+          rawPrefix,
+        ),
+      );
+      log('explainArgs', wrappedGraph);
       merge(results, wrappedGraph);
     };
 
@@ -213,7 +227,11 @@ export default class Db {
           }
         } else {
           const projection = node.children ? decodeQuery(node.children) : null;
-          promises.push(getByArgs(args, projection));
+          if (args.$explain) {
+            promises.push(explainArgs(args, projection));
+          } else {
+            promises.push(getByArgs(args, projection));
+          }
         }
       } else {
         idQueries[args] = node.children;

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -19,6 +19,7 @@ import debug from 'debug';
 import pg from 'pg';
 import sqlTag from 'sql-template-tag';
 import { del, patch, put, selectByArgs, selectByIds } from './sql/index.js';
+import formatSql from './sql/format.js';
 const log = debug('graffy:pg:db');
 const { Pool, Client, types } = pg;
 
@@ -96,7 +97,7 @@ export default class Db {
   /*
     Adds .schema to tableOptions if it doesn't exist yet.
     It mutates the argument, to "persist" the results and
-    avoid this query in every operation. 
+    avoid this query in every operation.
   */
   async ensureSchema(tableOptions, typeOids) {
     if (tableOptions.schema) return;
@@ -170,10 +171,15 @@ export default class Db {
     await this.ensureSchema(tableOptions);
 
     const getByArgs = async (args, projection) => {
-      const result = await this.readSql(
-        selectByArgs(args, projection, tableOptions),
-        tableOptions,
-      );
+      const sql = selectByArgs(args, projection, tableOptions);
+      // console.log('SQL', sql);
+      const result = await this.readSql(sql, tableOptions);
+      if (projection.$sql) {
+        for (const object of result) {
+          object.$sql = formatSql(sql);
+        }
+      }
+      // console.log('Result', result);
       const wrappedGraph = encodeGraph(wrapObject(result, rawPrefix));
       log('getByArgs', wrappedGraph);
       merge(results, wrappedGraph);
@@ -183,10 +189,8 @@ export default class Db {
       // TODO: Calculate a combined projection.
       // Bonus: Strategically split into multiple read operations
       // based on projection.
-      const result = await this.readSql(
-        selectByIds(Object.keys(idQueries), null, tableOptions),
-        tableOptions,
-      );
+      const sql = selectByIds(Object.keys(idQueries), null, tableOptions);
+      const result = await this.readSql(sql, tableOptions);
       for (const object of result) {
         const wrappedGraph = encodeGraph(wrapObject(object, rawPrefix));
         log('getByIds', wrappedGraph);

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -17,9 +17,9 @@ import {
 } from '@graffy/common';
 import debug from 'debug';
 import pg from 'pg';
+import { format } from 'sql-formatter';
 import sqlTag, { join as sqlJoin } from 'sql-template-tag';
 import formatSql from './sql/format.js';
-import { format } from 'sql-formatter';
 import { del, patch, put, selectByArgs, selectByIds } from './sql/index.js';
 const log = debug('graffy:pg:db');
 const { Pool, Client, types } = pg;

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -17,19 +17,11 @@ import {
 } from '@graffy/common';
 import debug from 'debug';
 import pg from 'pg';
-import { format } from 'sql-formatter';
 import sqlTag, { join as sqlJoin } from 'sql-template-tag';
 import formatSql from './sql/format.js';
 import { del, patch, put, selectByArgs, selectByIds } from './sql/index.js';
 const log = debug('graffy:pg:db');
 const { Pool, Client, types } = pg;
-
-const formatSqlValue = (value) =>
-  typeof value === 'number'
-    ? value.toString()
-    : typeof value === 'object'
-      ? `'${JSON.stringify(value)}'`
-      : `'${value}'`;
 
 export default class Db {
   constructor(connection) {

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -18,8 +18,8 @@ import {
 import debug from 'debug';
 import pg from 'pg';
 import sqlTag from 'sql-template-tag';
-import { del, patch, put, selectByArgs, selectByIds } from './sql/index.js';
 import formatSql from './sql/format.js';
+import { del, patch, put, selectByArgs, selectByIds } from './sql/index.js';
 const log = debug('graffy:pg:db');
 const { Pool, Client, types } = pg;
 

--- a/src/pg/Db.js
+++ b/src/pg/Db.js
@@ -17,7 +17,7 @@ import {
 } from '@graffy/common';
 import debug from 'debug';
 import pg from 'pg';
-import sqlTag, { join as sqlJoin } from 'sql-template-tag';
+import sqlTag from 'sql-template-tag';
 import formatSql from './sql/format.js';
 import { del, patch, put, selectByArgs, selectByIds } from './sql/index.js';
 const log = debug('graffy:pg:db');

--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -96,28 +96,25 @@ export const getSelectCols = (options, projection = null) => {
       sqls.push(
         sql`jsonb_build_object(${join(subSqls, ', ')}) AS "${raw(key)}"`,
       );
-    }
-
-    if (key[0] === '$') continue;
-
-    if (typeof projection[key] === 'object') {
-      const optimisedJsonBuild = getOptimisedJsonBuild(
-        projection[key],
-        [],
-        key,
-        options,
-      );
-
-      sqls.push(
-        sql`jsonb_build_object(${join(optimisedJsonBuild, ', ')}) AS "${raw(key)}"`,
-      );
     } else {
-      sqls.push(sql`"${raw(key)}"`);
+      if (typeof projection[key] === 'object') {
+        const optimisedJsonBuild = getOptimisedJsonBuild(
+          projection[key],
+          [],
+          key,
+          options,
+        );
+
+        sqls.push(
+          sql`jsonb_build_object(${join(optimisedJsonBuild, ', ')}) AS "${raw(key)}"`,
+        );
+      } else {
+        sqls.push(sql`"${raw(key)}"`);
+      }
     }
   }
 
-  // It needs at least one column.
-  return sqls.length ? join(sqls, ', ') : sql`TRUE AS "$"`;
+  return join(sqls, ', ');
 };
 
 function vertexSql(array, nullValue) {

--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -96,25 +96,28 @@ export const getSelectCols = (options, projection = null) => {
       sqls.push(
         sql`jsonb_build_object(${join(subSqls, ', ')}) AS "${raw(key)}"`,
       );
-    } else {
-      if (typeof projection[key] === 'object') {
-        const optimisedJsonBuild = getOptimisedJsonBuild(
-          projection[key],
-          [],
-          key,
-          options,
-        );
+    }
 
-        sqls.push(
-          sql`jsonb_build_object(${join(optimisedJsonBuild, ', ')}) AS "${raw(key)}"`,
-        );
-      } else {
-        sqls.push(sql`"${raw(key)}"`);
-      }
+    if (key[0] === '$') continue;
+
+    if (typeof projection[key] === 'object') {
+      const optimisedJsonBuild = getOptimisedJsonBuild(
+        projection[key],
+        [],
+        key,
+        options,
+      );
+
+      sqls.push(
+        sql`jsonb_build_object(${join(optimisedJsonBuild, ', ')}) AS "${raw(key)}"`,
+      );
+    } else {
+      sqls.push(sql`"${raw(key)}"`);
     }
   }
 
-  return join(sqls, ', ');
+  // It needs at least one column.
+  return sqls.length ? join(sqls, ', ') : sql`TRUE AS "$"`;
 };
 
 function vertexSql(array, nullValue) {

--- a/src/pg/sql/format.js
+++ b/src/pg/sql/format.js
@@ -9,7 +9,7 @@ export default function formatSql(sql) {
   const values = sql.values.slice(0);
   const output = [];
   while (strings.length) {
-    output.push(strings.shift().replace(/\s+/g, ' '));
+    output.push(strings.shift());
 
     if (!values.length) break;
     const value = values.shift();
@@ -21,5 +21,5 @@ export default function formatSql(sql) {
           : `'${value}'`,
     );
   }
-  return format(output.join('').trim(), { language: 'postgresql' });
+  return format(output.join(''), { language: 'postgresql' });
 }

--- a/src/pg/sql/format.js
+++ b/src/pg/sql/format.js
@@ -1,0 +1,19 @@
+export default function formatSql(sql) {
+  const strings = sql.strings.slice(0);
+  const values = sql.values.slice(0);
+  const output = [];
+  while (strings.length) {
+    output.push(strings.shift().replace(/\s+/g, ' '));
+
+    if (!values.length) break;
+    const value = values.shift();
+    output.push(
+      typeof value === 'number'
+        ? value.toString()
+        : typeof value === 'object'
+          ? `'${JSON.stringify(value)}'`
+          : `'${value}'`,
+    );
+  }
+  return output.join('').trim();
+}

--- a/src/pg/sql/format.js
+++ b/src/pg/sql/format.js
@@ -1,3 +1,9 @@
+import { format } from 'sql-formatter';
+
+/**
+ * @param {import('sql-template-tag').Sql} sql
+ * @returns {string}
+ */
 export default function formatSql(sql) {
   const strings = sql.strings.slice(0);
   const values = sql.values.slice(0);
@@ -15,5 +21,5 @@ export default function formatSql(sql) {
           : `'${value}'`,
     );
   }
-  return output.join('').trim();
+  return format(output.join('').trim(), { language: 'postgresql' });
 }

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1,16 +1,16 @@
 import Graffy from '@graffy/core';
 import { keyref, page, put, ref } from '@graffy/testing';
 import { jest } from '@jest/globals';
+import sql from 'sql-template-tag';
 import { v4 as uuid } from 'uuid';
 import { pg } from '../index.js';
+import expectSql from './expectSql.js';
 import {
   getPool,
   resetTables,
   setupPgServer,
   teardownPgServer,
 } from './setup.js';
-import expectSql from './expectSql.js';
-import sql from 'sql-template-tag';
 
 const uuidV4Regex =
   /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1204,7 +1204,30 @@ describe('pg_e2e', () => {
         plan: true,
       });
       expect(result[0].sql).toEqual(
-        'SELECT *, \'{"name":"alice"}\'::jsonb AS "$key", (EXTRACT(epoch FROM CURRENT_TIMESTAMP) * (1000)::numeric) AS "$ver", array[ \'users\'::text, "id" ]::text[] AS "$ref" FROM "users" WHERE "id" = ( SELECT "id" FROM "users" WHERE "name" = \'alice\' LIMIT 2 )',
+        'SELECT\n' +
+          '  *,\n' +
+          '  \'{"name":"alice"}\'::jsonb AS "$key",\n' +
+          '  (\n' +
+          '    EXTRACT(\n' +
+          '      epoch\n' +
+          '      FROM\n' +
+          '        CURRENT_TIMESTAMP\n' +
+          '    ) * (1000)::numeric\n' +
+          '  ) AS "$ver",\n' +
+          '  array[\'users\'::text, "id"]::text[] AS "$ref"\n' +
+          'FROM\n' +
+          '  "users"\n' +
+          'WHERE\n' +
+          '  "id" = (\n' +
+          '    SELECT\n' +
+          '      "id"\n' +
+          '    FROM\n' +
+          '      "users"\n' +
+          '    WHERE\n' +
+          '      "name" = \'alice\'\n' +
+          '    LIMIT\n' +
+          '      2\n' +
+          '  )',
       );
       expect(result[0].plan.Plan).toEqual(expect.any(Object));
       expect(result[0].plan.Planning).toBeUndefined();
@@ -1214,13 +1237,10 @@ describe('pg_e2e', () => {
 
     test('explain analyze', async () => {
       const result = await store.read(['users'], {
-        $key: { $explain: { name: 'alice', $analyze: true } },
+        $key: { $explain: { name: 'alice' }, analyze: true },
         sql: true,
         plan: true,
       });
-      expect(result[0].sql).toEqual(
-        'SELECT *, \'{"name":"alice"}\'::jsonb AS "$key", (EXTRACT(epoch FROM CURRENT_TIMESTAMP) * (1000)::numeric) AS "$ver", array[ \'users\'::text, "id" ]::text[] AS "$ref" FROM "users" WHERE "id" = ( SELECT "id" FROM "users" WHERE "name" = \'alice\' LIMIT 2 )',
-      );
       expect(result[0].plan.Plan).toEqual(expect.any(Object));
       expect(result[0].plan.Planning).toEqual(expect.any(Object));
       expect(result[0].plan['Planning Time']).toEqual(expect.any(Number));

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1,10 +1,8 @@
 import Graffy from '@graffy/core';
 import { keyref, page, put, ref } from '@graffy/testing';
 import { jest } from '@jest/globals';
-import sql from 'sql-template-tag';
 import { v4 as uuid } from 'uuid';
 import { pg } from '../index.js';
-import expectSql from './expectSql.js';
 import {
   getPool,
   resetTables,

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -9,6 +9,8 @@ import {
   setupPgServer,
   teardownPgServer,
 } from './setup.js';
+import expectSql from './expectSql.js';
+import sql from 'sql-template-tag';
 
 const uuidV4Regex =
   /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
@@ -1177,6 +1179,35 @@ describe('pg_e2e', () => {
         name: true,
       });
       expect(res2).toEqual([{ name: 'alice' }]);
+    });
+  });
+
+  describe('inspection', () => {
+    beforeEach(async () => {
+      await store.write(['users', uuid()], {
+        name: 'alice',
+        email: 'alice@acme.co',
+        settings: { foo: 3 },
+        $put: true,
+      });
+      await store.write(['users', uuid()], {
+        name: 'bob',
+        email: 'bob@acme.co',
+        settings: { bar: 5 },
+        $put: true,
+      });
+    });
+    test('sql', async () => {
+      const result = await store.read(['users'], {
+        $key: { name: 'alice' },
+        $sql: true,
+      });
+      expect(result[0].$sql).toEqual(
+        'SELECT TRUE AS "$", \'{"name":"alice"}\'::jsonb AS "$key", ' +
+          '(EXTRACT(epoch FROM CURRENT_TIMESTAMP) * (1000)::numeric) AS "$ver", ' +
+          'array[ \'users\'::text, "id" ]::text[] AS "$ref" FROM "users" ' +
+          'WHERE "id" = ( SELECT "id" FROM "users" WHERE "name" = \'alice\' LIMIT 2 )',
+      );
     });
   });
 });

--- a/src/pg/test/e2e.test.js
+++ b/src/pg/test/e2e.test.js
@@ -1197,17 +1197,34 @@ describe('pg_e2e', () => {
         $put: true,
       });
     });
-    test('sql', async () => {
+    test('explain', async () => {
       const result = await store.read(['users'], {
-        $key: { name: 'alice' },
-        $sql: true,
+        $key: { $explain: { name: 'alice' } },
+        sql: true,
+        plan: true,
       });
-      expect(result[0].$sql).toEqual(
-        'SELECT TRUE AS "$", \'{"name":"alice"}\'::jsonb AS "$key", ' +
-          '(EXTRACT(epoch FROM CURRENT_TIMESTAMP) * (1000)::numeric) AS "$ver", ' +
-          'array[ \'users\'::text, "id" ]::text[] AS "$ref" FROM "users" ' +
-          'WHERE "id" = ( SELECT "id" FROM "users" WHERE "name" = \'alice\' LIMIT 2 )',
+      expect(result[0].sql).toEqual(
+        'SELECT *, \'{"name":"alice"}\'::jsonb AS "$key", (EXTRACT(epoch FROM CURRENT_TIMESTAMP) * (1000)::numeric) AS "$ver", array[ \'users\'::text, "id" ]::text[] AS "$ref" FROM "users" WHERE "id" = ( SELECT "id" FROM "users" WHERE "name" = \'alice\' LIMIT 2 )',
       );
+      expect(result[0].plan.Plan).toEqual(expect.any(Object));
+      expect(result[0].plan.Planning).toBeUndefined();
+      expect(result[0].plan['Planning Time']).toBeUndefined();
+      expect(result[0].plan['Execution Time']).toBeUndefined();
+    });
+
+    test('explain analyze', async () => {
+      const result = await store.read(['users'], {
+        $key: { $explain: { name: 'alice', $analyze: true } },
+        sql: true,
+        plan: true,
+      });
+      expect(result[0].sql).toEqual(
+        'SELECT *, \'{"name":"alice"}\'::jsonb AS "$key", (EXTRACT(epoch FROM CURRENT_TIMESTAMP) * (1000)::numeric) AS "$ver", array[ \'users\'::text, "id" ]::text[] AS "$ref" FROM "users" WHERE "id" = ( SELECT "id" FROM "users" WHERE "name" = \'alice\' LIMIT 2 )',
+      );
+      expect(result[0].plan.Plan).toEqual(expect.any(Object));
+      expect(result[0].plan.Planning).toEqual(expect.any(Object));
+      expect(result[0].plan['Planning Time']).toEqual(expect.any(Number));
+      expect(result[0].plan['Execution Time']).toEqual(expect.any(Number));
     });
   });
 });

--- a/src/pg/test/setup.js
+++ b/src/pg/test/setup.js
@@ -30,6 +30,12 @@ const isPgReady = async () => {
 export async function setupPgServer() {
   // const start = Date.now();
   try {
+    await execFile('docker', ['rm', '-f', 'graffypg']);
+  } catch (_) {
+    // Do nothing if remove failed.
+  }
+
+  try {
     await execFile('docker', [
       'run',
       '-d',
@@ -44,10 +50,6 @@ export async function setupPgServer() {
   } catch (e) {
     console.error(
       'Could not start a test Postgres server using Docker.\n' +
-        'Possible reasons:\n' +
-        '1. You might not have Docker installed.\n' +
-        '2. The last test run might not have exited properly.\n' +
-        '   Run npm run pg:clean to fix this.\n' +
         'Docker might have printed a detailed error message above.',
     );
 


### PR DESCRIPTION
Support explain mode in reads: `$key: { $explain: { /* ...$key to inspect */ }, analyze: true } }`.

Apart from analyze, all other properties of $key are ignored while in explain mode. Analyze is optional.

Only two keys are supported in the projection:
- [x] `sql` to return the text SQL statement. (Caveat: graffy PG actually uses prepared statements with placeholders, but to be more useful this will interpolate the variables into a single SQL statement ready to paste into your favorite client.)
- [x] `plan` to return a JSON representation of the query plan. If `analyze: true` is passed, additional information is included in the plan.