### PR TITLE
pg null fix

### DIFF
--- a/src/pg/filter/getAst.js
+++ b/src/pg/filter/getAst.js
@@ -116,7 +116,7 @@ function simplify(node) {
   if (op === '$or') {
     const { eqmap, noneq, change } = node[1].reduce(
       (acc, item) => {
-        if (item[0] !== '$eq') {
+        if (item[0] !== '$eq' || item[2] === null) {
           acc.noneq.push(item);
         } else if (acc.eqmap[item[1]]) {
           acc.change = true;

--- a/src/pg/sql/format.js
+++ b/src/pg/sql/format.js
@@ -16,9 +16,11 @@ export default function formatSql(sql) {
     output.push(
       typeof value === 'number'
         ? value.toString()
-        : typeof value === 'object'
-          ? `'${JSON.stringify(value)}'`
-          : `'${value}'`,
+        : value === null
+          ? 'null'
+          : typeof value === 'object'
+            ? `'${JSON.stringify(value)}'`
+            : `'${value}'`,
     );
   }
   return format(output.join(''), { language: 'postgresql' });

--- a/src/pg/test/filter/getAst.test.js
+++ b/src/pg/test/filter/getAst.test.js
@@ -70,3 +70,34 @@ test('logic_inversion', () => {
     ],
   ]);
 });
+
+test('in_null', () => {
+  expect(
+    getAst({
+      foo: [null, 1, 2, 3],
+    })
+  ).toEqual([
+    '$or',
+    [
+      ['$eq', 'foo', null],
+      ['$in', 'foo', [1, 2, 3]],
+    ]
+  ]);
+});
+
+test('nin_null', () => {
+  expect(
+    getAst({
+      foo: { $not: [null, 1, 2, 3] }
+    })
+  ).toEqual([
+    '$not',
+    [
+      '$or',
+      [
+        ['$eq', 'foo', null],
+        ['$in', 'foo', [1, 2, 3]],
+      ]
+    ]
+  ]);
+});


### PR DESCRIPTION
Fixes #170

- pg: Fix formatting of `null` values in `formatSql` (`null` values were wrongly quoted as strings)
- pg: Fix SQL generation that results in `column IN (NULL, 1, 2, 3)` and `column NOT IN (NULL, 1, 2, 3)`
