### PR TITLE
pg: Rewrite sql formatter to support more types

### DIFF
--- a/src/pg/sql/format.js
+++ b/src/pg/sql/format.js
@@ -1,27 +1,42 @@
+import { escapeLiteral } from 'pg';
 import { format } from 'sql-formatter';
+
+/**
+ * @param {any} value
+ * @returns {string}
+ */
+function formatSqlParam(value) {
+  if (value === null || value === undefined) return 'null';
+  if (['number', 'boolean'].includes(typeof value)) return value.toString();
+
+  switch (typeof value) {
+    case 'number':
+    case 'boolean':
+      return value.toString();
+
+    case 'string':
+      return escapeLiteral(value);
+
+    case 'object':
+      if (Array.isArray(value))
+        return `array[${value.map(formatSqlParam).join(', ')}]`;
+      return `'${JSON.stringify(value)}'`;
+
+    default:
+      // shouldn't be reached
+      return '';
+  }
+}
 
 /**
  * @param {import('sql-template-tag').Sql} sql
  * @returns {string}
  */
 export default function formatSql(sql) {
-  const strings = sql.strings.slice(0);
-  const values = sql.values.slice(0);
-  const output = [];
-  while (strings.length) {
-    output.push(strings.shift());
-
-    if (!values.length) break;
-    const value = values.shift();
-    output.push(
-      typeof value === 'number'
-        ? value.toString()
-        : value === null
-          ? 'null'
-          : typeof value === 'object'
-            ? `'${JSON.stringify(value)}'`
-            : `'${value}'`,
-    );
-  }
-  return format(output.join(''), { language: 'postgresql' });
+  return format(sql.text, {
+    language: 'postgresql',
+    params: Object.fromEntries(
+      sql.values.map((value, idx) => [idx + 1, formatSqlParam(value)]),
+    ),
+  });
 }

--- a/src/pg/test/db/dbRead.test.js
+++ b/src/pg/test/db/dbRead.test.js
@@ -6,6 +6,7 @@ import expectSql from '../expectSql';
 const mockQuery = jest.fn();
 
 jest.unstable_mockModule('pg', () => ({
+  escapeLiteral: (s) => `'${s.replace("'", "''")}'`,
   default: {
     Pool: class {
       query = mockQuery;

--- a/src/pg/test/db/dbWrite.test.js
+++ b/src/pg/test/db/dbWrite.test.js
@@ -20,6 +20,7 @@ const mockQuery = jest.fn(() =>
 );
 
 jest.unstable_mockModule('pg', () => ({
+  escapeLiteral: (s) => `'${s.replace("'", "''")}'`,
   default: {
     Pool: class {
       query = mockQuery;


### PR DESCRIPTION
This PR fixes some bugs in the `$explain` sql formatter:
 - booleans were serialized as strings
 - arrays were serialized in json format which isn't valid postgresql syntax
 - string literals weren't escaped correctly

Before:
```js
// error when sql string has apostrophe (')
> console.log(require('./src/pg/sql/format').default(require('sql-template-tag').default`select null is ${null}, true is ${true}, 10 = ${10}, 10.10 = ${10.10}, string = ${"asdf'adsf"}, array = ${['array', 'of', 'strings']}, nested_array = ${[['array', 'of', 'array'], ['of', 'strings']]}, object = ${ ({"object": {"foo": "bar"} }) }::jsonb`))
Uncaught Error: Parse error: Unexpected "{"object":" at line 1 column 191.
SQL dialect used: "postgresql".
    at TokenizerEngine.createParseError (file:///home/hyperair/src/nektar/graffy/node_modules/sql-formatter/dist/esm/lexer/TokenizerEngine.js:40:16)
    at TokenizerEngine.tokenize (file:///home/hyperair/src/nektar/graffy/node_modules/sql-formatter/dist/esm/lexer/TokenizerEngine.js:30:32)
    at Tokenizer.tokenize (file:///home/hyperair/src/nektar/graffy/node_modules/sql-formatter/dist/esm/lexer/Tokenizer.js:20:69)

// booleans, arrays, nested arrays serailized wrongly
> console.log(require('./src/pg/sql/format').default(require('sql-template-tag').default`select null is ${null}, true is ${true}, 10 = ${10}, 10.10 = ${10.10}, string = ${"asdfadsf"}, array = ${['array', 'of', 'strings']}, nested_array = ${[['array', 'of', 'array'], ['of', 'strings']]}, object = ${ ({"object": {"foo": "bar"} }) }::jsonb`))
select
  null is null,
  true is 'true',
  10 = 10,
  10.10 = 10.1,
  string = 'asdfadsf',
  array = '["array","of","strings"]',
  nested_array = '[["array","of","array"],["of","strings"]]',
  object = '{"object":{"foo":"bar"}}'::jsonb
```

After:
```js
> console.log(require('./src/pg/sql/format').default(require('sql-template-tag').default`select null is ${null}, true is ${true}, 10 = ${10}, 10.10 = ${10.10}, string = ${"asdf'adsf"}, array = ${['array', 'of', 'strings']}, nested_array = ${[['array', 'of', 'array'], ['of', 'strings']]}, object = ${ ({"object": {"foo": "bar"} }) }::jsonb`))
select
  null is null,
  true is true,
  10 = 10,
  10.10 = 10.1,
  string = 'asdf''adsf',
  array = array['array', 'of', 'strings'],
  nested_array = array[array['array', 'of', 'array'], array['of', 'strings']],
  object = '{"object":{"foo":"bar"}}'::jsonb

```
