### PR TITLE
Add GH publishing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,8 +4,6 @@
 name: Node.js CI
 
 on:
-  push:
-    branches: [next]
   pull_request:
     branches: [next]
 
@@ -14,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -31,3 +29,12 @@ jobs:
           PGPORT: 5432
           PGUSER: postgres
           PGPASSWORD: postgres
+      - name: Read version from package.json
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      - name: Fail if tag already exists
+        run: |
+          if git tag --list "${{ steps.pkg.outputs.version }}" | grep -q .; then
+            echo "Error: tag ${{ steps.pkg.outputs.version }} already exists" >&2
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,18 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npx playwright install
+      - run: npm run lint
+      - run: npm test
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: postgres
       - name: Read version from package.json
         id: pkg
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
@@ -30,5 +39,3 @@ jobs:
           fi
       - run: npm install
       - run: npm run package -- ${{ steps.pkg.outputs.version }} --publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish
+
+on:
+  push:
+    branches: [next]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Read version from package.json
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+      - name: Fail if tag already exists
+        run: |
+          if git tag --list "${{ steps.pkg.outputs.version }}" | grep -q .; then
+            echo "Error: tag ${{ steps.pkg.outputs.version }} already exists" >&2
+            exit 1
+          fi
+      - run: npm install
+      - run: npm run package -- ${{ steps.pkg.outputs.version }} --publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -16,15 +16,23 @@ import { dst, src } from './utils.js';
 import version from './version.js';
 
 const argv = yargs(process.argv.slice(2))
-  .usage('$0 <version> [--publish] [--link] [--watch] [--notypes]')
+  .usage(
+    '$0 <version> [--publish] [--link] [--watch] [--notypes] [--provenance]',
+  )
   .boolean('publish')
   .boolean('link')
   .boolean('watch')
   .boolean('notypes')
+  .boolean('provenance')
   .demandCommand(1).argv;
 
 if (argv.publish && argv.watch) {
   console.log("ERR Can't both --publish and --watch");
+  process.exit(-1);
+}
+
+if (argv.provenance && !argv.publish) {
+  console.log('ERR --provenance requires --publish');
   process.exit(-1);
 }
 
@@ -50,7 +58,7 @@ function onUpdate(name, fileName) {
         console.log(`INFO [${name}] started`);
         if (!(await build(name, ver, argv.watch, onUpdate))) return;
         if (!argv.notypes) await types(name);
-        if (argv.publish) await publish(name, ver);
+        if (argv.publish) await publish(name, ver, argv.provenance);
         if (argv.link) await link(name);
         return name;
       },

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,6 +1,6 @@
 import { npm } from './utils.js';
 
-export default async function publish(name, version) {
+export default async function publish(name, version, provenance = false) {
   const isPre = version.includes('alpha') || version.includes('beta');
   try {
     await npm(
@@ -9,6 +9,7 @@ export default async function publish(name, version) {
       '--access',
       'public',
       ...(isPre ? ['--tag', 'pre'] : []),
+      ...(provenance ? ['--provenance'] : []),
     );
     console.log(`INFO [${name}] published`);
   } catch (e) {


### PR DESCRIPTION
Publish packages to NPM from GitHub actions, to allow any maintainer of this repo to publish new package versions simply by merging to `next`.