### PR TITLE
Batch ClickHouse write inserts

### DIFF
--- a/src/clickhouse/Db.ts
+++ b/src/clickhouse/Db.ts
@@ -328,6 +328,7 @@ export default class Db {
 
     const change = unwrap(rootChange, prefix);
     const result = [];
+    const rows = [];
 
     for (const node of change) {
       if (isRange(node)) {
@@ -348,9 +349,7 @@ export default class Db {
 
       const writtenRow = this.getWriteRow(object, tableOptions);
 
-      await this.insert(tableOptions, [
-        this.getInsertRow(writtenRow, tableOptions),
-      ]);
+      rows.push(this.getInsertRow(writtenRow, tableOptions));
 
       merge(
         result,
@@ -366,6 +365,8 @@ export default class Db {
         ),
       );
     }
+
+    await this.insert(tableOptions, rows);
 
     return result;
   }

--- a/src/clickhouse/test/db/dbWrite.test.ts
+++ b/src/clickhouse/test/db/dbWrite.test.ts
@@ -61,6 +61,46 @@ describe('clickhouse_db_write', () => {
     }
   });
 
+  test('multiple_puts_are_inserted_as_one_batch', async () => {
+    const query = mock.fn(async () => []);
+    const insert = mock.fn(async () => undefined);
+    const store = setupStore({ query, insert });
+
+    await store.write('users', [
+      {
+        $key: 'u1',
+        name: 'Alice',
+        settings: { foo: 10 },
+        $put: true,
+      },
+      {
+        $key: 'u2',
+        name: 'Bob',
+        email: 'bob@acme.co',
+        $put: true,
+      },
+    ]);
+
+    assert.strictEqual(query.mock.callCount(), 0);
+    assert.strictEqual(insert.mock.callCount(), 1);
+    assert.deepStrictEqual((insert.mock.calls as any[])[0].arguments[0], {
+      table: '`default`.`users`',
+      values: [
+        {
+          id: 'u1',
+          name: 'Alice',
+          settings: '{"foo":10}',
+        },
+        {
+          id: 'u2',
+          name: 'Bob',
+          email: 'bob@acme.co',
+        },
+      ],
+      format: 'JSONEachRow',
+    });
+  });
+
   test('put_by_id_quotes_hyphenated_database_name', async () => {
     const query = mock.fn(async () => []);
     const insert = mock.fn(async () => undefined);


### PR DESCRIPTION
## Summary
- Batch ClickHouse provider writes into a single `insert(...values)` call per Graffy write.
- Preserve existing validation/result shaping while moving the ClickHouse insert after all rows are built.
- Add a regression test that verifies multiple `$put` rows are inserted with one ClickHouse insert call.

## Root Cause
Graffy's ClickHouse `write()` path inserted each decoded Graffy node immediately, so one logical workLog flush with N rows created N ClickHouse insert queries and N MergeTree parts. Under high workLog volume this amplified query concurrency and part pressure.

## Impact
A logical multi-row `store.write()` now sends one ClickHouse insert request containing all rows in that write. This reduces query count and part creation from N per flush to 1 per flush.
